### PR TITLE
maven utf-8 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,9 @@
     <version>2.0-SNAPSHOT</version>
     <description>Carcassonne board game Java implementation</description>
     <url>http://www.jcloisterzone.org/</url>
-
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <repositories>
        <repository>
           <id>gettext-commons-site</id>


### PR DESCRIPTION
Fix forcing UTF-8 encoding in maven plugins compilation

([WARNING] File encoding has not been set, using platform encoding MacCentralEurope, i.e. build is platform dependent!)
