### PR TITLE
GameStateChangeEvent handling in GamePanel

### DIFF
--- a/src/main/java/com/jcloisterzone/ui/panel/GamePanel.java
+++ b/src/main/java/com/jcloisterzone/ui/panel/GamePanel.java
@@ -193,15 +193,18 @@ public class GamePanel extends BackgroundPanel {
 
     @Subscribe
     public void started(GameStateChangeEvent ev) {
-    	disposeCreateGamePanel();
-        removeAll();
-        setBackgroundImage(null);
-
-        createGamePanel = null;
-        connectedClientsPanel = null;
-        mainPanel = new MainPanel(client, gc, chatPanel);
-        add(mainPanel, BorderLayout.CENTER);
-        gc.getReportingTool().setContainer(getMainPanel());
-        mainPanel.started(ev.getSnapshot());
+    	
+    	if (GameStateChangeEvent.GAME_START == ev.getType()) {
+	    	disposeCreateGamePanel();
+	        removeAll();
+	        setBackgroundImage(null);
+	
+	        createGamePanel = null;
+	        connectedClientsPanel = null;
+	        mainPanel = new MainPanel(client, gc, chatPanel);
+	        add(mainPanel, BorderLayout.CENTER);
+	        gc.getReportingTool().setContainer(getMainPanel());
+	        mainPanel.started(ev.getSnapshot());
+    	}
     }
 }


### PR DESCRIPTION
Gameboard disappears when game ends. GamePanel.start(...) subscribes to GameStateChangeEvent but doens't take into account the event type (GAME_START).
