### PR TITLE
Split README.md to BUILDIND.md, CONTRIBUTING.md, updated copyright years

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,187 @@
+# Building [JCloisterZone](http://jcloisterzone.com/) from source
+
+
+Don't hesitate to ask if there are any problems with the explanations below!
+
+
+
+## Dependencies
+
+- [Java SE 7](http://www.oracle.com/technetwork/java/javase/downloads/) (JDK 1.7) as your `$JAVA_HOME`.
+- [Maven](https://maven.apache.org/) in your `$PATH`.
+- [gettext](https://www.gnu.org/software/gettext/) in your `$PATH`.
+- (optional) [Eclipse](https://eclipse.org/)
+
+
+
+## Package the latest version of the `master` branch.
+
+
+```bash
+cd your-development-folder    # Your own preference.
+                              # Get farin's fork of WebSockets.
+git clone https://github.com/farin/Java-WebSocket.git
+cd Java-WebSocket
+mvn install                   # Install the WebSockets fork version.
+cd - >/dev/null
+
+                              # Get JCloisterZone.
+git clone https://github.com/farin/JCloisterZone.git
+cd JCloisterZone
+mvn package                   # Create the main jar file.
+                              # Create the plugin/resource jar files.
+jar cfM build/plugins/classic.jar -C src/main/resources/plugins/classic .
+jar cfM build/plugins/rgg_siege.jar -C src/main/resources/plugins/rgg_siege .
+
+open build/JCloisterZone.jar  # Execute the game.
+```
+
+
+## Running in Eclipse
+
+### Java-WebSockets
+
+The special fork of WebSockets needs to be installed in Maven first.
+
+1. Clone the code from https://github.com/farin/Java-WebSocket.git
+1. "Import..." the "Java-WebSockets" project as an "Existing Maven project" from disk.
+1. Run the project as "Maven install" - it should now be available to the JCloisterZone project.
+
+
+### JCloisterZone
+
+1. Clone the code from https://github.com/farin/JCloisterZone.git
+1. "Import..." the "JCloisterZone" project as an "Existing Maven project" from disk.
+1. Right click the project and select "Update project..." from the Maven menu.
+1. Run the project as a java application; select `Bootstrap` (`com.jcloisterzone.ui.Bootstrap`) as the main class.
+
+
+
+## Troubleshooting
+
+### Can't find `$JAVA_HOME` or java compiler version errors.
+
+Maybe `$JAVA_HOME` was not set correctly. Try running `export JAVA_HOME=\`/usr/libexec/java_home -v 1.7\`` before running `mvn` in the same terminal window.
+
+
+### Can't find `msgfmt` so there are warnings for each language during `mvn package`.
+
+Maybe [gettext](https://www.gnu.org/software/gettext/) wasn't in your `$PATH`. Try installing/finding it on your harddrive, then add it to your path variable.
+
+
+
+## Development guide
+
+Helpers for more pleasant development and application debugging.
+
+### VM arguments
+
+Use different configuration file, don't create error.log (console out is enough), change log level and enable assertions
+
+    -Dconfig=debug.yaml -DerrorLog=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info -DforceChat -ea
+
+Command line example:
+
+```bash
+cd JCloisterZone
+java -jar build/JCloisterZone.jar -Dconfig=debug.yaml -DerrorLog=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info -DforceChat -ea
+```
+
+
+### `debug.yaml`
+
+Tweaked `config.yaml`
+
+Use unpacked plugins from source.
+
+```yaml
+plugins:
+  - plugins/classic
+  - plugins/rgg_siege
+```
+
+For immediately AI play comment delay option.
+
+```yaml
+# ai_place_tile_delay: 250
+```
+
+#### Debug options
+
+Use debug options for quick and repeatable game setup with following possible options
+
+```yaml
+debug:
+  # use some keys described below ...
+```
+
+Don't compress saves, autosave before each AI play.
+
+```yaml
+save_format: plain
+autosave: saves/_prerank.jcz
+```
+
+Skip game config dialog, player is name or AI class.
+You can comment just preset key to disable whole autostart.
+
+```yaml
+autostart:
+  preset: default
+  players:
+    - Alice
+    - Bob
+    - com.jcloisterzone.ai.legacyplayer.LegacyAiPlayer
+    - com.jcloisterzone.ai.DummyAiPlayer
+```
+
+Developing expansion, don't bother with basic tiles. Override any expansion with own set definition.
+
+```yaml
+tile_definitions:
+  BASIC: tile-definitions/basic-1card.xml
+```
+
+Force drawn tiles.
+
+```yaml
+draw:
+  - BA.C
+  - BA.Cccc+
+```
+
+And then force final scoring with dot item.
+
+```yaml
+draw:
+# ... some tiles ...
+- .
+```
+
+Experimental options
+
+```yaml
+off_capabilities: [ Dragon, Fairy ]
+area_highlight: figure
+```
+
+### `gettext`
+
+```bash
+xgettext -k_ -o po/keys.pot --from-code=utf-8 $(find . -name "*.java")
+msgmerge -N -U po/cs.po po/keys.pot
+msgmerge -N -U po/de.po po/keys.pot
+msgmerge -N -U po/el.po po/keys.pot
+msgmerge -N -U po/en.po po/keys.pot
+msgmerge -N -U po/es.po po/keys.pot
+msgmerge -N -U po/fi.po po/keys.pot
+msgmerge -N -U po/fr.po po/keys.pot
+msgmerge -N -U po/hu.po po/keys.pot
+msgmerge -N -U po/it.po po/keys.pot
+msgmerge -N -U po/pl.po po/keys.pot
+msgmerge -N -U po/ro.po po/keys.pot
+msgmerge -N -U po/ru.po po/keys.pot
+msgmerge -N -U po/sk.po po/keys.pot
+rm po/*~
+rm po/keys.pot
+```

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,39 @@
+# Contributing to [JCloisterZone](http://jcloisterzone.com/)
+
+
+
+## I found a bug. How to report it?
+
+Sorry for that. The preferred way is to [look through the existing issues](https://github.com/farin/JCloisterZone/issues) on the project's GitHub pages. If the bug has not already been reported you can create a new issue. Alternatively send an email. Attaching a saved game and `error.log` (if created) may be helpful.
+
+
+
+## In which ways can I contribute?
+
+I am glad for any help — suggestions, localizations, design or programming contributions, beta testing or donations are welcomed. Just get in touch!
+
+
+
+## I'm a programmer, can I change and improve the code?
+
+Yes, the help would be much appreciated!
+
+
+### Code style
+Regarding code style like indentation and whitespace, **follow the conventions you see used in the source already.**
+
+
+### Running and modifying the code
+
+Build your own version from source by reading [BUILDING.md](https://github.com/farin/JCloisterZone/blob/master/BUILDING.md).
+
+
+
+### Submitting pull requests
+
+1. Create a new branch, please don't work in your `master` branch directly.
+1. Add failing tests for the change you want to make. Run `mvn test` to see the tests fail.
+1. Fix stuff.
+1. Run `mvn test` to see if the tests pass. Repeat steps 2-4 until done.
+1. Update the documentation to reflect any changes.
+1. Push to your fork and submit a pull request.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 JCloisterZone
-Copyright (C) 2004-2013 Roman Krejcik
+Copyright (C) 2004-2014 Roman Krejcik
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as

--- a/README.md
+++ b/README.md
@@ -1,94 +1,18 @@
-# JCloisterZone
+# [JCloisterZone](http://jcloisterzone.com/)
 
-JCloisterZone is a Java implementation of a popular board game Carcassonne.
+
+JCloisterZone is a Java implementation of a popular board game [Carcassonne](https://en.wikipedia.org/wiki/Carcassonne_(board_game)).
 It supports multiplayer game on a local computer or over a network.
-Game can be also played against computer AI.
-
-## Development guide
-
-Helpers for more pleasant development and application debugging.
-
-### VM arguments
-
-use different configuration file, don't create error.log (console out is enough), change log level and enable assertions
-
-    -Dconfig=debug.yaml -DerrorLog=false -Dorg.slf4j.simpleLogger.defaultLogLevel=info -DforceChat -ea
+Games can be also played against computer AI.
+The game contains [many of the available expansions](http://www.boardgamegeek.com/boardgame/822/carcassonne), including the small ones, distributed during game expos or in a game magazines.
 
 
-### debug.yaml
+- Download ready-made packages at [jcloisterzone.com](http://jcloisterzone.com/).
+- Build your own version from source by reading [BUILDING.md](https://github.com/farin/JCloisterZone/blob/master/BUILDING.md).
+- Contribute to the project by reading [CONTRIBUTE.md](https://github.com/farin/JCloisterZone/blob/master/CONTRIBUTE.md).
 
-tweaked config.yaml
 
-use unpacked plugins from source
 
-    plugins:
-      - plugins/classic
-      - plugins/rgg_siege
+---
 
-for immediately AI play comment delay option
-
-    # ai_place_tile_delay: 250
-
-#### debug options
-
-use debug options for quick and repeatable game setup with following possible options
-
-    debug:
-      # use some keys described below ...
-
-don't compress saves, autosave before each AI play
-
-    save_format: plain
-    autosave: saves/_prerank.jcz
-
-skip game config dialog, player is name or AI class
-you can comment just preset key to disable whole autostart
-
-    autostart:
-      preset: default
-      players:
-        - Alice
-        - Bob
-        - com.jcloisterzone.ai.legacyplayer.LegacyAiPlayer
-        - com.jcloisterzone.ai.DummyAiPlayer
-
-developing expansion, don't bother with basic tiles. Override any expansion with own set definition.
-
-    tile_definitions:
-      BASIC: tile-definitions/basic-1card.xml
-
-force drawn tiles
-
-    draw:
-      - BA.C
-      - BA.Cccc+
-
-and then force final scoring with dot item
-
-    draw:
-       # ... some tiles ...
-       - .
-
-experimental options
-
-    off_capabilities: [ Dragon, Fairy ]
-    area_highlight: figure
-
-### gettext
-
-    xgettext -k_ -o po/keys.pot --from-code=utf-8 $(find . -name "*.java")
-    msgmerge -N -U po/cs.po po/keys.pot
-    msgmerge -N -U po/de.po po/keys.pot
-    msgmerge -N -U po/el.po po/keys.pot
-    msgmerge -N -U po/en.po po/keys.pot
-    msgmerge -N -U po/es.po po/keys.pot
-    msgmerge -N -U po/fi.po po/keys.pot
-    msgmerge -N -U po/fr.po po/keys.pot
-    msgmerge -N -U po/hu.po po/keys.pot
-    msgmerge -N -U po/it.po po/keys.pot
-    msgmerge -N -U po/pl.po po/keys.pot
-    msgmerge -N -U po/ro.po po/keys.pot
-    msgmerge -N -U po/ru.po po/keys.pot
-    msgmerge -N -U po/sk.po po/keys.pot
-    rm po/*~
-    rm po/keys.pot
+JCloisterZone copyright (C) 2004-2014 [Roman Krejčík](http://farin.cz) ([@farin](https://github.com/farin/)). Licensed under the [GNU Affero General Public License, Version 3 (AGPL-3.0)](https://www.gnu.org/licenses/agpl-3.0.html).


### PR DESCRIPTION
This rewrite focuses the README.md to show only the basic information. Information on contributing is copied from the main webpage to CONTRIBUTION.md - this file is also linked to by github when new issues are reported. Development information is moved to BUILDING.md.
