### PR TITLE
Define a code style and auto-format routines

### DIFF
--- a/eclipse-formatter-config.xml
+++ b/eclipse-formatter-config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<profiles version="12">
+    <profile kind="CodeFormatterProfile" name="JCloisterZone Project Formatter" version="12">
+    </profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
+                <artifactId>maven-java-formatter-plugin</artifactId>
+                <version>0.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                        <configuration>
+                            <configFile>${project.basedir}/eclipse-formatter-config.xml</configFile>
+                            <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
+                            <lineEnding>LF</lineEnding>
+                            <encoding>UTF-8</encoding>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
In order to keep both the maintainer and contributors sane, I propose defining a code style.
- Reduces time and brainpower spent as formatting is not done ad hoc/by hand.
- Minimizes patch/merge differences between branches.
- Reduces maintenance.

I Defined a style we can share, based on the default Eclipse code style formatter configuration, to start with. Also added [maven-java-formatter-plugin](https://code.google.com/p/maven-java-formatter-plugin/) to `pom.xml`, which is used during package (build) time.

The current auto-formatter style might not be perfect, but it's a start. This way, any code will at least be standardized - and any changes to the code style are tracked through `eclipse-formatter-config.xml`.

The first time the code formatter is used on any new branch, the code might change a lot. This is ok - it is changing exactly the same way across everyones machines so merging will be no problem. This also means that all active branches should run the code formatter once before being merged. This can be done by the maintainer or by individual contributors.

Steps to update a branch to follow the new code style:

``` bash
cd JCloisterZone
git checkout your-branch    # Select the branch to update.
git status                  # Check to make sure you've commit all your code changes.
git cherry-pick 9d049b9     # Get the updated pom.xml and eclipse-formatter-config.xml.
mvn clean
mvn package                 # This will also format the code.
git add -u                  # Add all updated files.
git commit -m "Code style auto-format"
```

The Maven plugin only formats java code. Later on, maybe an [.editorconfig](http://editorconfig.org/) file can be added, to normalize XML files etcetera. There's an [.editorconfig Eclipse plugin](https://github.com/ncjones/editorconfig-eclipse) as well.
