### PR TITLE
Create Typos in German Version

### DIFF
--- a/Typos in German Version
+++ b/Typos in German Version
@@ -1,0 +1,4 @@
+Startbildschirm bzw. Fenster mit Steuerung: "Drücke Ffür die Wiesenmarkierung..." Abstand fehlt
+"Die Festspiele (10. Jubiläum)" richtiger Name "Das Fest"
+Abtei und Bürgermeister: "Erlauben das Setzten einer Scheune auf bereits vorhandene Scheunen." richtiger Ausdruck: Gutshof (Wiesen werden ja auch nicht als Farmen rückübersetzt
+Der Tunnel: Typo Tunner statt Tunnel in "Verwende die Tunnelregeln auf Tunner in anderen Erweiterungen"


### PR DESCRIPTION
+Startbildschirm bzw. Fenster mit Steuerung: "Drücke Ffür die Wiesenmarkierung..." Abstand fehlt
+"Die Festspiele (10. Jubiläum)" richtiger Name "Das Fest"
+Abtei und Bürgermeister: "Erlauben das Setzten einer Scheune auf bereits vorhandene Scheunen." richtiger Ausdruck: Gutshof (Wiesen werden ja auch nicht als Farmen rückübersetzt
+Der Tunnel: Typo Tunner statt Tunnel in "Verwende die Tunnelregeln auf Tunner in anderen Erweiterungen"