### PR TITLE
Bridge meeple overlay

### DIFF
--- a/src/main/resources/defaults/points.xml
+++ b/src/main/resources/defaults/points.xml
@@ -101,8 +101,6 @@
     </point>
     <point feature="FARM" cx="800" cy="300">
         <apply allRotations="1">* NR.EL.ER</apply>
-    </point>
-    <point feature="FARM" cx="800" cy="500">
         <apply allRotations="1">* NR.EL.ER.SL</apply>
     </point>
 


### PR DESCRIPTION
When playing Fairy/Dragon in combination with bridges, it is possible to
get more than one meeple on the same tile.

For a straight road (WE) with a bridge (NS): when a meeple is placed on
the bridge, and one is placed on the farm (N), only the bridge meeple is
visible. (+ rotations).
Moving the point 

config for a NR.EL.ER.SL farm away from the middle makes both meeples visible.

Before:
![bug-bridge-magic-portal](https://cloud.githubusercontent.com/assets/10167314/10981380/c7ddb9d8-8407-11e5-9676-20bbce31b1e6.JPG)


After:
![bug-bridge-magic-portal-fix](https://cloud.githubusercontent.com/assets/10167314/10981390/d471e02a-8407-11e5-8720-70a063ee4d6a.JPG)