### PR TITLE
Solution for: ignore caps lock for keyboard shortcuts #64

### DIFF
--- a/src/main/java/com/jcloisterzone/ui/view/GameView.java
+++ b/src/main/java/com/jcloisterzone/ui/view/GameView.java
@@ -326,6 +326,7 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             if (result) e.consume();
             return result;
         } else if (e.getID() == KeyEvent.KEY_TYPED) {
+        	e.setKeyChar(Character.toLowerCase(e.getKeyChar()));
             return dispatchKeyTyped(e);
         }
         return false;


### PR DESCRIPTION
After long investigation this is the neatest solution I could find.
Simply if we got key pressed and it is a letter we convert it to lower
case before we proceed.
This means that JCZ is not case sensitive anymore and it cannot
distinguish cases.