### PR TITLE
Issue #193 - Purist mode

### DIFF
--- a/src/main/java/com/jcloisterzone/action/AbbeyPlacementAction.java
+++ b/src/main/java/com/jcloisterzone/action/AbbeyPlacementAction.java
@@ -1,6 +1,7 @@
 package com.jcloisterzone.action;
 
 import java.awt.Image;
+import java.util.Set;
 
 import com.jcloisterzone.Player;
 import com.jcloisterzone.board.Position;
@@ -10,7 +11,8 @@ import com.jcloisterzone.ui.grid.layer.AbbeyPlacementLayer;
 import com.jcloisterzone.wsio.RmiProxy;
 
 public class AbbeyPlacementAction extends SelectTileAction {
-
+	private Set<Position> occupiedPositions = null;
+	
     public AbbeyPlacementAction() {
         super("abbeyplacement");
     }
@@ -23,6 +25,14 @@ public class AbbeyPlacementAction extends SelectTileAction {
     @Override
     public void perform(RmiProxy server, Position p) {
         server.placeTile(Rotation.R0, p);
+    }
+
+    public void setOccupiedPositions(Set<Position> occupiedPositions) {
+    	this.occupiedPositions = occupiedPositions;
+    }
+
+    public Set<Position> getOccupiedPositions() {
+    	return occupiedPositions;
     }
 
     @Override

--- a/src/main/java/com/jcloisterzone/action/TilePlacementAction.java
+++ b/src/main/java/com/jcloisterzone/action/TilePlacementAction.java
@@ -25,7 +25,7 @@ public class TilePlacementAction extends PlayerAction<TilePlacement> implements 
 
     private final Tile tile;
     private ForwardBackwardListener forwardBackwardDelegate;
-
+    private Set<Position> occupiedPositions = null;
     private Rotation tileRotation = Rotation.R0;
 
     public TilePlacementAction(Tile tile) {
@@ -66,6 +66,14 @@ public class TilePlacementAction extends PlayerAction<TilePlacement> implements 
             rotations.add(tp.getRotation());
         }
         return map;
+    }
+
+    public void setOccupiedPositions(Set<Position> occupiedPositions) {
+    	this.occupiedPositions = occupiedPositions;
+    }
+
+    public Set<Position> getOccupiedPositions() {
+    	return occupiedPositions;
     }
 
     public Set<Rotation> getRotations(Position p) {

--- a/src/main/java/com/jcloisterzone/board/Board.java
+++ b/src/main/java/com/jcloisterzone/board/Board.java
@@ -30,6 +30,7 @@ public class Board {
     protected final Map<Position, EdgePattern> availMoves = new HashMap<>();
     protected final Map<Position, Set<Rotation>> currentAvailMoves = new HashMap<>();
     protected final Set<Position> holes = new HashSet<>();
+    protected final Set<Position> occupied = new HashSet<>();
 
     private int maxX, minX, maxY, minY;
 
@@ -84,6 +85,10 @@ public class Board {
         return availMoves.get(pos);
     }
 
+    public Set<Position> getOccupied() {
+        return occupied;
+    }
+
 
     /**
      * Place tile on given position. Check for correct placement (check if neigbours
@@ -113,6 +118,7 @@ public class Board {
         }
 
         tiles.put(p, tile);
+        occupied.add(p);
         availMovesRemove(p);
 
         for (Position offset: Position.ADJACENT.values()) {

--- a/src/main/java/com/jcloisterzone/game/CustomRule.java
+++ b/src/main/java/com/jcloisterzone/game/CustomRule.java
@@ -31,7 +31,9 @@ public enum CustomRule {
 
     BULDINGS_DIFFERENT_VALUE(Expansion.LITTLE_BUILDINGS, Boolean.class, _("Add 3/2/1 points for tower/house/shed.")),
 
-    CLOCK_PLAYER_TIME(null, Integer.class, null);
+    CLOCK_PLAYER_TIME(null, Integer.class, null),
+
+    TABLETOP_MODE(null, Boolean.class, _("Tabletop mode"));
 
 
     String label;

--- a/src/main/java/com/jcloisterzone/game/CustomRule.java
+++ b/src/main/java/com/jcloisterzone/game/CustomRule.java
@@ -33,7 +33,7 @@ public enum CustomRule {
 
     CLOCK_PLAYER_TIME(null, Integer.class, null),
 
-    TABLETOP_MODE(null, Boolean.class, _("Tabletop mode"));
+    PURIST_MODE(null, Boolean.class, _("Purist mode"));
 
 
     String label;

--- a/src/main/java/com/jcloisterzone/game/phase/AbbeyPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/AbbeyPhase.java
@@ -38,7 +38,10 @@ public class AbbeyPhase extends ServerAwarePhase {
         if (builderSecondTurnPart || !baazaarInProgress) {
             if (abbeyCap.hasUnusedAbbey(getActivePlayer()) && !getBoard().getHoles().isEmpty()) {
                 toggleClock(getActivePlayer());
-                game.post(new SelectActionEvent(getActivePlayer(), new AbbeyPlacementAction().addAll(getBoard().getHoles()), true));
+                AbbeyPlacementAction action = new AbbeyPlacementAction();
+                action.addAll(getBoard().getHoles());
+                action.setOccupiedPositions(getBoard().getOccupied());
+                game.post(new SelectActionEvent(getActivePlayer(), action, true));
                 return;
             }
         }
@@ -52,6 +55,9 @@ public class AbbeyPhase extends ServerAwarePhase {
 
     @Override
     public void placeTile(Rotation rotation, Position position) {
+    	if (!getBoard().getHoles().contains(position)) {
+    		return;
+    	}
         abbeyCap.useAbbey(getActivePlayer());
 
         Tile nextTile = game.getTilePack().drawTile("inactive", Tile.ABBEY_TILE_ID);

--- a/src/main/java/com/jcloisterzone/game/phase/TilePhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/TilePhase.java
@@ -34,6 +34,7 @@ public class TilePhase extends Phase {
                 action.add(new TilePlacement(entry.getKey(), rotation));
             }
         }
+        action.setOccupiedPositions(getBoard().getOccupied());
         game.post(new SelectActionEvent(getActivePlayer(), action, false));
     }
 

--- a/src/main/java/com/jcloisterzone/ui/controls/ControlPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/controls/ControlPanel.java
@@ -70,6 +70,7 @@ public class ControlPanel extends JPanel {
     public static final int LEFT_MARGIN = 15;
     public static final int ACTIVE_MARKER_SIZE = 25;
     public static final int ACTIVE_MARKER_PADDING = 6;
+    public static final int LAST_TILES_SHOWN = 12;
 
     private static final String PASS_LABEL = _("Skip");
     private static final String CONFIRMATION_LABEL = _("Continue");
@@ -83,6 +84,7 @@ public class ControlPanel extends JPanel {
     private boolean showConfirmRequest;
     private boolean canPass;
     private boolean showProjectedPoints, projectedPointsValid = true;
+    private boolean hideTilePackSize;
 
     private ActionPanel actionPanel;
     private PlayerPanel[] playerPanels;
@@ -232,7 +234,7 @@ public class ControlPanel extends JPanel {
             g2.setFont(FONT_PACK_SIZE);
             g2.setColor(client.getTheme().getHeaderFontColor());
             int packSize = tilePack.totalSize();
-            g2.drawString("" + packSize, w - 42, 24);
+            g2.drawString(hideTilePackSize && packSize > LAST_TILES_SHOWN ? ">" + LAST_TILES_SHOWN : "" + packSize, w - 42, 24);
         }
 
         boolean doRevalidate = false;
@@ -354,6 +356,10 @@ public class ControlPanel extends JPanel {
                 }
             }
         });
+    }
+    
+    public void setHideTilePackSize(boolean hideTilePackSize) {
+        this.hideTilePackSize = hideTilePackSize;
     }
 
     public void setShowConfirmRequest(boolean showConfirmRequest) {

--- a/src/main/java/com/jcloisterzone/ui/controls/ControlPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/controls/ControlPanel.java
@@ -70,7 +70,6 @@ public class ControlPanel extends JPanel {
     public static final int LEFT_MARGIN = 15;
     public static final int ACTIVE_MARKER_SIZE = 25;
     public static final int ACTIVE_MARKER_PADDING = 6;
-    public static final int LAST_TILES_SHOWN = 12;
 
     private static final String PASS_LABEL = _("Skip");
     private static final String CONFIRMATION_LABEL = _("Continue");
@@ -84,7 +83,6 @@ public class ControlPanel extends JPanel {
     private boolean showConfirmRequest;
     private boolean canPass;
     private boolean showProjectedPoints, projectedPointsValid = true;
-    private boolean hideTilePackSize;
 
     private ActionPanel actionPanel;
     private PlayerPanel[] playerPanels;
@@ -234,7 +232,7 @@ public class ControlPanel extends JPanel {
             g2.setFont(FONT_PACK_SIZE);
             g2.setColor(client.getTheme().getHeaderFontColor());
             int packSize = tilePack.totalSize();
-            g2.drawString(hideTilePackSize && packSize > LAST_TILES_SHOWN ? ">" + LAST_TILES_SHOWN : "" + packSize, w - 42, 24);
+            g2.drawString("" + packSize, w - 42, 24);
         }
 
         boolean doRevalidate = false;
@@ -356,10 +354,6 @@ public class ControlPanel extends JPanel {
                 }
             }
         });
-    }
-    
-    public void setHideTilePackSize(boolean hideTilePackSize) {
-        this.hideTilePackSize = hideTilePackSize;
     }
 
     public void setShowConfirmRequest(boolean showConfirmRequest) {

--- a/src/main/java/com/jcloisterzone/ui/grid/MainPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/MainPanel.java
@@ -89,6 +89,11 @@ public class MainPanel extends JPanel {
         }
     }
 
+    public void setPlayersAid(boolean playersAid) {
+    	TilePlacementLayer layer = getGridPanel().findLayer(TilePlacementLayer.class);
+        layer.setPlayersAid(playersAid);
+    }
+
     public void started(Snapshot snapshot) {
         controlPanel = new ControlPanel(gameView);
         gridPanel = new GridPanel(client, gameView, controlPanel, chatPanel, snapshot);

--- a/src/main/java/com/jcloisterzone/ui/grid/layer/AbbeyPlacementLayer.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/layer/AbbeyPlacementLayer.java
@@ -24,6 +24,7 @@ public class AbbeyPlacementLayer extends AbstractTilePlacementLayer implements A
         this.action = action;
         setActive(active);
         setAvailablePositions(action == null ? null : action.getOptions());
+        setOccupiedPositions(action == null ? null : action.getOccupiedPositions());
     }
 
     @Override

--- a/src/main/java/com/jcloisterzone/ui/grid/layer/AbstractTilePlacementLayer.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/layer/AbstractTilePlacementLayer.java
@@ -6,6 +6,7 @@ import java.awt.Composite;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.event.MouseEvent;
+import java.util.HashSet;
 import java.util.Set;
 
 import com.jcloisterzone.board.Position;
@@ -19,7 +20,9 @@ public abstract class AbstractTilePlacementLayer extends AbstractGridLayer imple
     protected static final Composite DISALLOWED_PREVIEW = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .4f);
 
     private boolean active;
+    protected boolean playersAid;
     private Set<Position> availablePositions;
+    private Set<Position> occupiedPositions;
 
     private Position previewPosition;
     private Image previewIcon;
@@ -32,6 +35,10 @@ public abstract class AbstractTilePlacementLayer extends AbstractGridLayer imple
     public void setAvailablePositions(Set<Position> availablePositions) {
         this.availablePositions = availablePositions;
     }
+    
+    void setOccupiedPositions(Set<Position> occupiedPositions) {
+    	this.occupiedPositions = occupiedPositions;
+    }
 
     public Position getPreviewPosition() {
         return previewPosition;
@@ -43,6 +50,10 @@ public abstract class AbstractTilePlacementLayer extends AbstractGridLayer imple
 
     public void setActive(boolean active) {
         this.active = active;
+    }
+
+    public void setPlayersAid(boolean playersAid) {
+    	this.playersAid = playersAid;
     }
 
 
@@ -64,7 +75,7 @@ public abstract class AbstractTilePlacementLayer extends AbstractGridLayer imple
         if (availablePositions == null) return;
         int borderSize = getSquareSize() - 4,
             shift = 2,
-            thickness = borderSize/14;
+            thickness = playersAid ? borderSize/14 : 0;
 
         g2.setColor(getClient().getTheme().getTilePlacementColor());
         for (Position p : availablePositions) {
@@ -89,7 +100,7 @@ public abstract class AbstractTilePlacementLayer extends AbstractGridLayer imple
 
     @Override
     public void squareEntered(MouseEvent e, Position p) {
-        if (availablePositions.contains(p)) {
+        if ((!playersAid && !occupiedPositions.contains(p)) || availablePositions.contains(p)) {
             previewPosition = p;
             gridPanel.repaint();
         }

--- a/src/main/java/com/jcloisterzone/ui/grid/layer/TilePlacementLayer.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/layer/TilePlacementLayer.java
@@ -69,12 +69,12 @@ public class TilePlacementLayer extends AbstractTilePlacementLayer implements Ac
         previewRotation = realRotation;
 
         Set<Rotation> allowedRotations = action.getRotations(p);
-        if (allowedRotations.contains(previewRotation)) {
+        if (allowedRotations.isEmpty()) {
+        	allowedRotation = false;
+        } else if (allowedRotations.contains(previewRotation)) {
             allowedRotation = true;
         } else {
-            if (!playersAid) {
-            	allowedRotation = false;
-            } else if (allowedRotations.size() == 1) {
+        	if (allowedRotations.size() == 1) {
                 previewRotation = allowedRotations.iterator().next();
                 allowedRotation = true;
             } else if (action.getTile().getSymmetry() == TileSymmetry.S2) {
@@ -99,7 +99,7 @@ public class TilePlacementLayer extends AbstractTilePlacementLayer implements Ac
     private void rotate(Rotation spin) {
     	Rotation current = action.getTileRotation();
     	Rotation next = current.add(spin);
-    	if (playersAid && getPreviewPosition() != null) {
+    	if (getPreviewPosition() != null) {
     		Set<Rotation> rotations = action.getRotations(getPreviewPosition());
     		if (!rotations.isEmpty()) {
 	    		if (rotations.size() == 1) {

--- a/src/main/java/com/jcloisterzone/ui/grid/layer/TilePlacementLayer.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/layer/TilePlacementLayer.java
@@ -39,6 +39,7 @@ public class TilePlacementLayer extends AbstractTilePlacementLayer implements Ac
         } else {
         	action.setForwardBackwardDelegate(this);
             setAvailablePositions(action.groupByPosition().keySet());
+            setOccupiedPositions(action.getOccupiedPositions());
         };
     }
 
@@ -71,7 +72,9 @@ public class TilePlacementLayer extends AbstractTilePlacementLayer implements Ac
         if (allowedRotations.contains(previewRotation)) {
             allowedRotation = true;
         } else {
-            if (allowedRotations.size() == 1) {
+            if (!playersAid) {
+            	allowedRotation = false;
+            } else if (allowedRotations.size() == 1) {
                 previewRotation = allowedRotations.iterator().next();
                 allowedRotation = true;
             } else if (action.getTile().getSymmetry() == TileSymmetry.S2) {
@@ -96,7 +99,7 @@ public class TilePlacementLayer extends AbstractTilePlacementLayer implements Ac
     private void rotate(Rotation spin) {
     	Rotation current = action.getTileRotation();
     	Rotation next = current.add(spin);
-    	if (getPreviewPosition() != null) {
+    	if (playersAid && getPreviewPosition() != null) {
     		Set<Rotation> rotations = action.getRotations(getPreviewPosition());
     		if (!rotations.isEmpty()) {
 	    		if (rotations.size() == 1) {

--- a/src/main/java/com/jcloisterzone/ui/panel/CreateGamePanel.java
+++ b/src/main/java/com/jcloisterzone/ui/panel/CreateGamePanel.java
@@ -199,7 +199,7 @@ public class CreateGamePanel extends ThemedJPanel {
             playersPanel.add(randomSeating, "wrap, gaptop 10");
             ruleCheckboxes.put(CustomRule.RANDOM_SEATING_ORDER, randomSeating);
         }
-//////////////////////////////////////////////////////////////////
+
         modePanel = new ThemedJPanel();
         if (!client.getTheme().isDark()) {
             modePanel.setBorder(new TitledBorder(null, _("Modes"),
@@ -207,12 +207,12 @@ public class CreateGamePanel extends ThemedJPanel {
         }
         modePanel.setLayout(new MigLayout("", "[][][]", ""));
 
-        JCheckBox tabletopModeChbox = createRuleCheckbox(CustomRule.TABLETOP_MODE, mutableSlots);///////////////////////
-        modePanel.add(tabletopModeChbox);
-        ruleCheckboxes.put(CustomRule.TABLETOP_MODE, tabletopModeChbox);//////////////////////////////////////////////
+        JCheckBox puristModeChbox = createRuleCheckbox(CustomRule.PURIST_MODE, mutableSlots);
+        modePanel.add(puristModeChbox);
+        ruleCheckboxes.put(CustomRule.PURIST_MODE, puristModeChbox);
 
         playersPanel.add(modePanel, "wrap, gaptop 10, grow");        
-////////////////////////////////////////////////////////////////////////////////        
+      
         playersPanel.add(createClockPanel(), "wrap, gaptop 10, grow");
 
         scrolled.add(playersPanel, "cell 0 0, grow");

--- a/src/main/java/com/jcloisterzone/ui/panel/CreateGamePanel.java
+++ b/src/main/java/com/jcloisterzone/ui/panel/CreateGamePanel.java
@@ -80,6 +80,7 @@ public class CreateGamePanel extends ThemedJPanel {
     private JButton presetSave, presetDelete;
 
     private JButton leaveGameButton, startGameButton;
+    private JPanel modePanel;
     private JPanel expansionPanel;
     private JPanel rulesPanel;
     private JPanel header;
@@ -198,7 +199,20 @@ public class CreateGamePanel extends ThemedJPanel {
             playersPanel.add(randomSeating, "wrap, gaptop 10");
             ruleCheckboxes.put(CustomRule.RANDOM_SEATING_ORDER, randomSeating);
         }
+//////////////////////////////////////////////////////////////////
+        modePanel = new ThemedJPanel();
+        if (!client.getTheme().isDark()) {
+            modePanel.setBorder(new TitledBorder(null, _("Modes"),
+                TitledBorder.LEADING, TitledBorder.TOP, null, null));
+        }
+        modePanel.setLayout(new MigLayout("", "[][][]", ""));
 
+        JCheckBox tabletopModeChbox = createRuleCheckbox(CustomRule.TABLETOP_MODE, mutableSlots);///////////////////////
+        modePanel.add(tabletopModeChbox);
+        ruleCheckboxes.put(CustomRule.TABLETOP_MODE, tabletopModeChbox);//////////////////////////////////////////////
+
+        playersPanel.add(modePanel, "wrap, gaptop 10, grow");        
+////////////////////////////////////////////////////////////////////////////////        
         playersPanel.add(createClockPanel(), "wrap, gaptop 10, grow");
 
         scrolled.add(playersPanel, "cell 0 0, grow");

--- a/src/main/java/com/jcloisterzone/ui/view/GameView.java
+++ b/src/main/java/com/jcloisterzone/ui/view/GameView.java
@@ -31,6 +31,7 @@ import com.jcloisterzone.Player;
 import com.jcloisterzone.bugreport.BugReportDialog;
 import com.jcloisterzone.config.Config.DebugConfig;
 import com.jcloisterzone.event.ClientListChangedEvent;
+import com.jcloisterzone.game.CustomRule;
 import com.jcloisterzone.game.Game;
 import com.jcloisterzone.game.Snapshot;
 import com.jcloisterzone.ui.Client;
@@ -103,6 +104,10 @@ public class GameView extends AbstractUiView implements WindowStateListener {
         timer = new Timer(true);
         timer.scheduleAtFixedRate(new KeyRepeater(), 0, 40);
 
+        boolean tabletopMode = game.getBooleanValue(CustomRule.TABLETOP_MODE);
+        mainPanel.setPlayersAid(!tabletopMode);
+        mainPanel.getControlPanel().setHideTilePackSize(tabletopMode);
+
         MenuBar menu = client.getJMenuBar();
         menu.setItemActionListener(MenuItem.SAVE, new ActionListener() {
             @Override
@@ -152,7 +157,7 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             }
         });
         if (menu.isSelected(MenuItem.FARM_HINTS)) {
-        	mainPanel.setShowFarmHints(true);
+        	mainPanel.setShowFarmHints(!tabletopMode);
         }
         menu.setItemActionListener(MenuItem.PROJECTED_POINTS, new ActionListener() {
             @Override
@@ -162,7 +167,7 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             }
         });
         if (menu.isSelected(MenuItem.PROJECTED_POINTS)) {
-        	getControlPanel().setShowProjectedPoints(true);
+        	getControlPanel().setShowProjectedPoints(!tabletopMode);
         }
         menu.setItemActionListener(MenuItem.DISCARDED_TILES, new ActionListener() {
             @Override
@@ -195,10 +200,10 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             }
         });
 
-        menu.setItemEnabled(MenuItem.FARM_HINTS, true);
-        menu.setItemEnabled(MenuItem.LAST_PLACEMENTS, true);
-        menu.setItemEnabled(MenuItem.PROJECTED_POINTS, true);
+	    menu.setItemEnabled(MenuItem.FARM_HINTS, !tabletopMode);
+	    menu.setItemEnabled(MenuItem.PROJECTED_POINTS, !tabletopMode);
 
+        menu.setItemEnabled(MenuItem.LAST_PLACEMENTS, true);
         menu.setItemEnabled(MenuItem.REPORT_BUG, true);
         menu.setItemEnabled(MenuItem.GAME_SETUP, true);
         menu.setItemEnabled(MenuItem.TAKE_SCREENSHOT, true);

--- a/src/main/java/com/jcloisterzone/ui/view/GameView.java
+++ b/src/main/java/com/jcloisterzone/ui/view/GameView.java
@@ -104,9 +104,8 @@ public class GameView extends AbstractUiView implements WindowStateListener {
         timer = new Timer(true);
         timer.scheduleAtFixedRate(new KeyRepeater(), 0, 40);
 
-        boolean tabletopMode = game.getBooleanValue(CustomRule.TABLETOP_MODE);
-        mainPanel.setPlayersAid(!tabletopMode);
-        mainPanel.getControlPanel().setHideTilePackSize(tabletopMode);
+        boolean puristMode = game.getBooleanValue(CustomRule.PURIST_MODE);
+        mainPanel.setPlayersAid(!puristMode);
 
         MenuBar menu = client.getJMenuBar();
         menu.setItemActionListener(MenuItem.SAVE, new ActionListener() {
@@ -157,7 +156,7 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             }
         });
         if (menu.isSelected(MenuItem.FARM_HINTS)) {
-        	mainPanel.setShowFarmHints(!tabletopMode);
+        	mainPanel.setShowFarmHints(!puristMode);
         }
         menu.setItemActionListener(MenuItem.PROJECTED_POINTS, new ActionListener() {
             @Override
@@ -167,7 +166,7 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             }
         });
         if (menu.isSelected(MenuItem.PROJECTED_POINTS)) {
-        	getControlPanel().setShowProjectedPoints(!tabletopMode);
+        	getControlPanel().setShowProjectedPoints(!puristMode);
         }
         menu.setItemActionListener(MenuItem.DISCARDED_TILES, new ActionListener() {
             @Override
@@ -200,8 +199,8 @@ public class GameView extends AbstractUiView implements WindowStateListener {
             }
         });
 
-	    menu.setItemEnabled(MenuItem.FARM_HINTS, !tabletopMode);
-	    menu.setItemEnabled(MenuItem.PROJECTED_POINTS, !tabletopMode);
+	    menu.setItemEnabled(MenuItem.FARM_HINTS, !puristMode);
+	    menu.setItemEnabled(MenuItem.PROJECTED_POINTS, !puristMode);
 
         menu.setItemEnabled(MenuItem.LAST_PLACEMENTS, true);
         menu.setItemEnabled(MenuItem.REPORT_BUG, true);


### PR DESCRIPTION
An option (rule) to play JCZ in a mode resembling what we have in a plain tabletop game. It includes:
-disabled Farm Hints and Projected Scores
-counter of remaining tiles doesn't show an exact value until there's few of them left (12)
-there's no highlighting of acceptable tile locations
-these acceptable tile locations could still be spotted by players by projecting or not an image of a tile when cursor entered a corresponding space, so I also changed it to always project that image
-there's no auto-rotation of a tile

That's just a special rule for those who want to play tournament-like games and it doesn't change a regular play.
