### PR TITLE
Option to choose the follower to get back in prisoner exchange

### DIFF
--- a/src/main/java/com/jcloisterzone/ai/DelayedServer.java
+++ b/src/main/java/com/jcloisterzone/ai/DelayedServer.java
@@ -78,6 +78,10 @@ public class DelayedServer implements RmiProxy {
         server.payRansom(playerIndexToPay, meepleType);
     }
 
+    public void exchangePrisoners(Class<? extends Follower> meepleType) {
+        server.exchangePrisoners(meepleType);
+    }
+
     @Override
     public void deployBridge(Position pos, Location loc) {
         server.deployBridge(pos, loc);

--- a/src/main/java/com/jcloisterzone/event/PrisonerExchangedEvent.java
+++ b/src/main/java/com/jcloisterzone/event/PrisonerExchangedEvent.java
@@ -1,0 +1,10 @@
+package com.jcloisterzone.event;
+
+import com.jcloisterzone.Player;
+
+@Idempotent
+public class PrisonerExchangedEvent extends PlayEvent {
+    public PrisonerExchangedEvent(Player player) {
+        super(null, player);
+    }
+}

--- a/src/main/java/com/jcloisterzone/event/SelectPrisonerToExchangeEvent.java
+++ b/src/main/java/com/jcloisterzone/event/SelectPrisonerToExchangeEvent.java
@@ -1,0 +1,10 @@
+package com.jcloisterzone.event;
+
+import com.jcloisterzone.Player;
+
+@Idempotent
+public class SelectPrisonerToExchangeEvent extends PlayEvent {
+    public SelectPrisonerToExchangeEvent(Player player) {
+        super(null, player);
+    }
+}

--- a/src/main/java/com/jcloisterzone/game/capability/TowerCapability.java
+++ b/src/main/java/com/jcloisterzone/game/capability/TowerCapability.java
@@ -237,7 +237,7 @@ public final class TowerCapability extends Capability {
         Iterator<Follower> i = prisoners.get(opponent).iterator();
         while (i.hasNext()) {
             Follower meeple = i.next();
-            if (meeple.getClass() == meepleType) {
+            if (meeple.getClass() == meepleType && meeple.getPlayer() == game.getActivePlayer()) {
                 i.remove();
                 meeple.setInPrison(false);
                 opponent.addPoints(RANSOM_POINTS, PointCategory.TOWER_RANSOM);

--- a/src/main/java/com/jcloisterzone/game/capability/TowerCapability.java
+++ b/src/main/java/com/jcloisterzone/game/capability/TowerCapability.java
@@ -237,7 +237,7 @@ public final class TowerCapability extends Capability {
         Iterator<Follower> i = prisoners.get(opponent).iterator();
         while (i.hasNext()) {
             Follower meeple = i.next();
-            if (meepleType.isInstance(meeple)) {
+            if (meeple.getClass() == meepleType) {
                 i.remove();
                 meeple.setInPrison(false);
                 opponent.addPoints(RANSOM_POINTS, PointCategory.TOWER_RANSOM);

--- a/src/main/java/com/jcloisterzone/game/phase/CreateGamePhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/CreateGamePhase.java
@@ -123,6 +123,7 @@ public class CreateGamePhase extends ServerAwarePhase {
         }
 
         next = addPhase(next, new PhantomPhase(game));
+               addPhase(next, new PrisonerExchangePhase(game));
                addPhase(next, new TowerCapturePhase(game));
                addPhase(next, new FlierActionPhase(game));
         next = addPhase(next, new ActionPhase(game));

--- a/src/main/java/com/jcloisterzone/game/phase/Phase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/Phase.java
@@ -161,6 +161,11 @@ public abstract class Phase implements RmiProxy {
     }
 
     @Override
+    public void exchangePrisoners(Class<? extends Follower> meepleType) {
+         logger.error(Application.ILLEGAL_STATE_MSG, "exchangePrisoners");
+    }    
+
+    @Override
     public void deployBridge(Position pos, Location loc) {
         logger.error(Application.ILLEGAL_STATE_MSG, "deployBridge");
 

--- a/src/main/java/com/jcloisterzone/game/phase/PrisonerExchangePhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/PrisonerExchangePhase.java
@@ -1,0 +1,52 @@
+package com.jcloisterzone.game.phase;
+
+import java.util.List;
+
+import com.jcloisterzone.event.PrisonerExchangedEvent;
+import com.jcloisterzone.event.SelectPrisonerToExchangeEvent;
+import com.jcloisterzone.figure.Follower;
+import com.jcloisterzone.game.Game;
+import com.jcloisterzone.game.capability.TowerCapability;
+
+
+public class PrisonerExchangePhase extends Phase {
+
+    private final TowerCapability towerCap;
+
+    public PrisonerExchangePhase(Game game) {
+        super(game);
+        towerCap = game.getCapability(TowerCapability.class);
+    }
+
+    @Override
+    public boolean isActive() {
+        return game.hasCapability(TowerCapability.class);
+    }
+
+    @Override
+    public void enter() {
+        game.post(new SelectPrisonerToExchangeEvent(getActivePlayer()));
+    }
+
+    @Override
+    public void exchangePrisoners(Class<? extends Follower> meepleType) {
+        int lastPos = towerCap.getPrisoners().get(game.getActivePlayer()).size() - 1;
+        List<Follower> opponentPrisoners = towerCap.getPrisoners().get(towerCap.getPrisoners().get(game.getActivePlayer()).get(lastPos).getPlayer());
+        List<Follower> myPrisoners = towerCap.getPrisoners().get(game.getActivePlayer());
+        for (Follower exchanged: opponentPrisoners) {
+            if (exchanged.getClass() == meepleType) {
+                boolean removeOk = opponentPrisoners.remove(exchanged);
+                assert removeOk;
+                exchanged.setInPrison(false);
+
+                towerCap.getPrisoners().get(game.getActivePlayer()).get(lastPos).setInPrison(false);
+                game.post(new PrisonerExchangedEvent(towerCap.getPrisoners().get(game.getActivePlayer()).get(lastPos).getPlayer()));
+                removeOk = myPrisoners.remove(towerCap.getPrisoners().get(game.getActivePlayer()).get(lastPos));
+                assert removeOk;
+
+                next();
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/jcloisterzone/game/phase/TowerCapturePhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/TowerCapturePhase.java
@@ -63,24 +63,34 @@ public class TowerCapturePhase extends Phase {
             TowerCapability towerCap = game.getCapability(TowerCapability.class);
             List<Follower> prisoners = towerCap.getPrisoners().get(m.getPlayer());
             List<Follower> myCapturedFollowers = new ArrayList<>();
+            boolean moreThanOneKind = false;
             for (Follower f : prisoners) {
                 if (f.getPlayer() == me) {
                     myCapturedFollowers.add(f);
+                    if (f.getClass() != myCapturedFollowers.get(0).getClass()) {
+                        moreThanOneKind = true;
+                    }
                 }
             }
 
             if (myCapturedFollowers.isEmpty()) {
                 towerCap.inprison(m, me);
+                next();
             } else {
                 //opponent has my prisoner - figure exchange
-                Follower exchanged = myCapturedFollowers.get(0); //TODO same type?
-                boolean removeOk = prisoners.remove(exchanged);
-                assert removeOk;
-                exchanged.setInPrison(false);
-                game.post(new MeeplePrisonEvent(exchanged, m.getPlayer(), null));
+                if (moreThanOneKind) {
+                    towerCap.inprison(m, me);
+                    next(PrisonerExchangePhase.class);
+                } else {
+                    Follower exchanged = myCapturedFollowers.get(0);
+                    boolean removeOk = prisoners.remove(exchanged);
+                    assert removeOk;
+                    exchanged.setInPrison(false);
+                    game.post(new MeeplePrisonEvent(exchanged, m.getPlayer(), null));
+                    next();
+                }
             }
-        }
-        next();
+        } 
     }
 
     @Override

--- a/src/main/java/com/jcloisterzone/ui/GameController.java
+++ b/src/main/java/com/jcloisterzone/ui/GameController.java
@@ -28,6 +28,8 @@ import com.jcloisterzone.event.GameStateChangeEvent;
 import com.jcloisterzone.event.MageWitchSelectRemoval;
 import com.jcloisterzone.event.MeeplePrisonEvent;
 import com.jcloisterzone.event.PlayerTurnEvent;
+import com.jcloisterzone.event.PrisonerExchangedEvent;
+import com.jcloisterzone.event.SelectPrisonerToExchangeEvent;
 import com.jcloisterzone.event.RequestConfirmEvent;
 import com.jcloisterzone.event.SelectActionEvent;
 import com.jcloisterzone.event.SelectDragonMoveEvent;
@@ -39,11 +41,13 @@ import com.jcloisterzone.game.capability.BazaarItem;
 import com.jcloisterzone.game.phase.Phase;
 import com.jcloisterzone.ui.MenuBar.MenuItem;
 import com.jcloisterzone.ui.controls.ControlPanel;
+import com.jcloisterzone.ui.controls.PlayerPanelImageCache;
 import com.jcloisterzone.ui.dialog.DiscardedTilesDialog;
 import com.jcloisterzone.ui.grid.BazaarPanel;
 import com.jcloisterzone.ui.grid.BazaarPanel.BazaarPanelState;
 import com.jcloisterzone.ui.grid.CornCirclesPanel;
 import com.jcloisterzone.ui.grid.GridPanel;
+import com.jcloisterzone.ui.grid.PrisonerExchangePanel;
 import com.jcloisterzone.ui.grid.SelectMageWitchRemovalPanel;
 import com.jcloisterzone.ui.panel.GameOverPanel;
 import com.jcloisterzone.ui.resources.LayeredImageDescriptor;
@@ -195,6 +199,11 @@ public class GameController extends EventProxyUiController<Game> implements Invo
 
     @Subscribe
     public void handleMeeplePrisonEvent(MeeplePrisonEvent ev) {
+        PrisonerExchangePanel panel = gameView.getGridPanel().getPrisonerExchangePanel();
+        if (panel != null){
+            panel.updateChoices();
+        }
+
         gameView.getGridPanel().repaint();
     }
 
@@ -268,6 +277,16 @@ public class GameController extends EventProxyUiController<Game> implements Invo
         return panel;
     }
 
+    public PrisonerExchangePanel showPrisonerExchangePanel() {
+        PrisonerExchangePanel panel = gameView.getGridPanel().getPrisonerExchangePanel();
+        if (panel == null) {
+            panel = new PrisonerExchangePanel(client, gameView.getGameController(), new PlayerPanelImageCache(client, game));
+            gameView.getGridPanel().add(panel, "pos (100%-525) 0 (100%-275) 100%"); //TODO more robust layouting
+            gameView.getGridPanel().setPrisonerExchangePanel(panel);
+        }
+        return panel;
+    }
+
     @Subscribe
     public void handleSelectBazaarTile(BazaarSelectTileEvent ev) {
         clearActions();
@@ -325,6 +344,22 @@ public class GameController extends EventProxyUiController<Game> implements Invo
         if (panel != null) {
             gameView.getGridPanel().remove(panel);
             gameView.getGridPanel().setBazaarPanel(null);
+        }
+    }
+
+    @Subscribe
+    public void handleSelectPrisonerToExchange(SelectPrisonerToExchangeEvent ev) {
+        clearActions();
+        showPrisonerExchangePanel();
+        gameView.getGridPanel().repaint();
+    }
+
+    @Subscribe
+    public void handlePrisonerExchangedEvent(PrisonerExchangedEvent ev) {
+        PrisonerExchangePanel panel = gameView.getGridPanel().getPrisonerExchangePanel();
+        if (panel != null) {
+            gameView.getGridPanel().remove(panel);
+            gameView.getGridPanel().setPrisonerExchangePanel(null);
         }
     }
 

--- a/src/main/java/com/jcloisterzone/ui/grid/GridPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/GridPanel.java
@@ -64,6 +64,7 @@ public class GridPanel extends JPanel implements ForwardBackwardListener {
     private final ChatPanel chatPanel;
     private BazaarPanel bazaarPanel;
     private SelectMageWitchRemovalPanel mageWitchPanel;
+    private PrisonerExchangePanel prisonerExchangePanel;
 
     /** current board size */
     private int left, right, top, bottom;
@@ -286,6 +287,13 @@ public class GridPanel extends JPanel implements ForwardBackwardListener {
         this.mageWitchPanel = mageWitchPanel;
     }
 
+    public PrisonerExchangePanel getPrisonerExchangePanel() {
+        return prisonerExchangePanel;
+    }
+
+    public void setPrisonerExchangePanel(PrisonerExchangePanel prisonerReleasePanel) {
+        this.prisonerExchangePanel = prisonerReleasePanel;
+    }
 
     public void moveCenter(int xSteps, int ySteps) {
         //step should be 30px

--- a/src/main/java/com/jcloisterzone/ui/grid/PrisonerExchangePanel.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/PrisonerExchangePanel.java
@@ -1,0 +1,107 @@
+package com.jcloisterzone.ui.grid;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import net.miginfocom.swing.MigLayout;
+
+import com.jcloisterzone.figure.Follower;
+import com.jcloisterzone.game.capability.TowerCapability;
+import com.jcloisterzone.ui.Client;
+import com.jcloisterzone.ui.GameController;
+import com.jcloisterzone.ui.controls.PlayerPanelImageCache;
+import com.jcloisterzone.ui.gtk.ThemedJLabel;
+import com.jcloisterzone.ui.gtk.ThemedJPanel;
+
+import static com.jcloisterzone.ui.I18nUtils._;
+
+@InteractionPanel
+public class PrisonerExchangePanel extends JPanel {
+    final Client client;
+    final GameController gc;
+    final TowerCapability towerCap;
+    final PlayerPanelImageCache cache;    
+
+    private static final Color TRANSPARENT_COLOR = new Color(0, 0, 0, 0);
+    public static Font FONT_HEADER = new Font(null, Font.BOLD, 18);
+
+    private List<FollowerItem> options;
+
+    public PrisonerExchangePanel(Client client, GameController gc, PlayerPanelImageCache cache) {
+        this.client = client;
+        this.gc = gc;
+        this.cache = cache;
+        this.towerCap = gc.getGame().getCapability(TowerCapability.class);
+
+        setOpaque(true);
+        setBackground(gc.getClient().getTheme().getTransparentPanelBg());
+        setLayout(new MigLayout("ins 10", "[grow]", ""));
+
+        JLabel label = new ThemedJLabel(_("Exchange prisoners"));
+        label.setFont(FONT_HEADER);
+        label.setForeground(gc.getClient().getTheme().getHeaderFontColor());
+        add(label, "wrap");
+
+        int lastPos = towerCap.getPrisoners().get(gc.getGame().getActivePlayer()).size() - 1;
+        add(new FollowerItem(towerCap.getPrisoners().get(gc.getGame().getActivePlayer()).get(lastPos)), "wrap, gapbottom 5, growx, h 50");
+        label = new ThemedJLabel(_("Choose your follower to exchange:"));
+        add(label, "wrap");
+
+        List<Follower> prisoners = towerCap.getPrisoners().get(towerCap.getPrisoners().get(gc.getGame().getActivePlayer()).get(lastPos).getPlayer());
+        options = new ArrayList<FollowerItem>();
+        for (Follower f : prisoners) {
+            if (f.getPlayer() == gc.getGame().getActivePlayer()) {
+                options.add(new FollowerItem(f));
+                add(options.get(options.size() - 1), "wrap, gap 0, growx, h 50");
+            }
+        }
+    }
+
+    class FollowerItem extends ThemedJPanel {
+        final Follower follower;
+
+        public FollowerItem(Follower follower) {
+            this.follower = follower;
+            setOpaque(false);
+            setBackground(TRANSPARENT_COLOR);
+            setLayout(new MigLayout("ins 0", "", ""));
+
+            addMouseListener(new MouseAdapter() {
+                @Override
+                public void mouseClicked(MouseEvent e) {
+                    if (follower.getPlayer() == gc.getGame().getActivePlayer()) {
+                        gc.getRmiProxy().exchangePrisoners(follower.getClass());
+                    }
+                }
+            });
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            Graphics2D g2 = (Graphics2D) g;
+            Image img = cache.get(follower.getPlayer(), follower.getClass().getSimpleName());
+            g2.drawImage(img, 20, 20, null);
+        }
+    }
+
+    public void updateChoices() {
+        
+        for (FollowerItem o: options) {
+            int lastPos = towerCap.getPrisoners().get(gc.getGame().getActivePlayer()).size() - 1;
+            if (!towerCap.getPrisoners().get(towerCap.getPrisoners().get(gc.getGame().getActivePlayer()).get(lastPos).getPlayer()).contains(o.follower)) {
+                remove(o);
+            }
+        }
+    }
+}

--- a/src/main/java/com/jcloisterzone/wsio/RmiProxy.java
+++ b/src/main/java/com/jcloisterzone/wsio/RmiProxy.java
@@ -29,6 +29,8 @@ public interface RmiProxy {
 
     public void takePrisoner(MeeplePointer mp);
     public void payRansom(Integer playerIndexToPay, Class<? extends Follower> meepleType);
+    public void exchangePrisoners(Class<? extends Follower> meepleType);
+    
 
     public void deployBridge(Position pos, Location loc); //TODO use FeaturePointer
     public void deployCastle(Position pos, Location loc); //TODO use FeaturePointer


### PR DESCRIPTION
(Issue #59)
If Player A has captured more than one type of meeples of Player B and Player B captures one of his meeples, causing a prisoner exchange, then Player B can choose which one he wants to retrieve.

Also, while testing this on Phantom expansion, I noticed that the function of paying a ransom sometimes works wrong and releases a different meeple than a player wants. For example, when someone captured my phantom, then a small follower and I want to pay a ransom for a small follower, a phantom is released instead. The isInstance method of comparing classes was the reason.
