### PR TITLE
Update org.java-websocket dependency to official version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.3.1-SNAPSHOT</version>
+            <version>1.3.4</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/jcloisterzone/wsio/server/SimpleServer.java
+++ b/src/main/java/com/jcloisterzone/wsio/server/SimpleServer.java
@@ -196,6 +196,11 @@ public class SimpleServer extends WebSocketServer  {
     }
 
     @Override
+    public void onStart() {
+
+    }
+
+    @Override
     public void onMessage(WebSocket ws, String payload) {
         //logger.info(payload);
         WsMessage msg = parser.fromJson(payload);


### PR DESCRIPTION
The pom.xml file was updated 3 years ago in commit 0c6d04029f0cf64820eb6aef7a9a68509ef18bfc to use a patched version of websocket. The changes in farin's fork ( https://github.com/farin/Java-WebSocket/commit/bdfeb347be317ef74489a3daaf52666ffd90c80e ) have been applied 5 months / 1 month ago in the official version ( https://github.com/TooTallNate/Java-WebSocket/commit/6f40675a88ef312f2938ba2453158584ebfc9650 and https://github.com/TooTallNate/Java-WebSocket/commit/c0cc4ef129294ccdf4197780f19a2f895b0ef79d ).

So I guess JCloisterZone can now depend on the new version of the official release. This will make it easier to build since there is no cloning of a custom repo involved.

The new version of Websocket, however, has a new abstract method onStart() in WebSocketServer. This has to be overridden in SimpleServer class.

Fixes #235 .