### PR TITLE
Time consumed of game

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -963,7 +963,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/de.po
+++ b/po/de.po
@@ -965,7 +965,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/el.po
+++ b/po/el.po
@@ -953,7 +953,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/en.po
+++ b/po/en.po
@@ -941,7 +941,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/es.po
+++ b/po/es.po
@@ -964,7 +964,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/fi.po
+++ b/po/fi.po
@@ -956,7 +956,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/fr.po
+++ b/po/fr.po
@@ -971,7 +971,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/hu.po
+++ b/po/hu.po
@@ -961,7 +961,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/it.po
+++ b/po/it.po
@@ -963,7 +963,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/ja.po
+++ b/po/ja.po
@@ -968,7 +968,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/nl.po
+++ b/po/nl.po
@@ -964,7 +964,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/pl.po
+++ b/po/pl.po
@@ -962,7 +962,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/ro.po
+++ b/po/ro.po
@@ -967,7 +967,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/ru.po
+++ b/po/ru.po
@@ -968,7 +968,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/sk.po
+++ b/po/sk.po
@@ -953,7 +953,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/po/zh.po
+++ b/po/zh.po
@@ -956,7 +956,7 @@ msgid "Tiles placed"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:146
-msgid "Time consumed"
+msgid "Time consumed:(Player/Game)"
 msgstr ""
 
 #: src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java:148

--- a/src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java
@@ -143,7 +143,7 @@ public class GameOverPanel extends JPanel {
             add(new JLabel(_tr("Rank")), getLegendSpec(0, gridy++));
             add(new JLabel(_tr("Total points")), getLegendSpec(0, gridy++));
             add(new JLabel(_tr("Tiles placed")), getLegendSpec(0, gridy++));
-            add(new JLabel(_tr("Time consumed")), getLegendSpec(0, gridy++));
+            add(new JLabel(_tr("Time consumed\n(Player/Game)")), getLegendSpec(0, gridy++));
 
             add(new JLabel(_tr("Roads")), getLegendSpec(0, gridy++));
             add(new JLabel(_tr("Cities")), getLegendSpec(0, gridy++));
@@ -210,7 +210,7 @@ public class GameOverPanel extends JPanel {
                 fullseconds = fullseconds % 3600;
                 int fullminutes = fullseconds / 60;
                 fullseconds = fullseconds % 60;
-                add(new JLabel(String.format("%d:%02d:%02d/%d:%02d:%02d", hours, minutes, seconds, fullhours, fullminutes, fullseconds), SwingConstants.CENTER), getSpec(gridx, gridy++));
+                add(new JLabel(String.format("%d:%02d:%02d/\n%d:%02d:%02d", hours, minutes, seconds, fullhours, fullminutes, fullseconds), SwingConstants.CENTER), getSpec(gridx, gridy++));
                
                 add(new JLabel("" +player.getPointsInCategory(state, PointCategory.ROAD), SwingConstants.CENTER), getSpec(gridx, gridy++));
                 add(new JLabel("" +player.getPointsInCategory(state, PointCategory.CITY), SwingConstants.CENTER), getSpec(gridx, gridy++));

--- a/src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java
@@ -143,7 +143,7 @@ public class GameOverPanel extends JPanel {
             add(new JLabel(_tr("Rank")), getLegendSpec(0, gridy++));
             add(new JLabel(_tr("Total points")), getLegendSpec(0, gridy++));
             add(new JLabel(_tr("Tiles placed")), getLegendSpec(0, gridy++));
-            add(new JLabel(_tr("Time consumed\n(Player/Game)")), getLegendSpec(0, gridy++));
+            add(new JLabel(_tr("Time consumed:(Player/Game)")), getLegendSpec(0, gridy++));
 
             add(new JLabel(_tr("Roads")), getLegendSpec(0, gridy++));
             add(new JLabel(_tr("Cities")), getLegendSpec(0, gridy++));

--- a/src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java
@@ -181,6 +181,11 @@ public class GameOverPanel extends JPanel {
             }
 
             Player[] players = getSortedPlayers().toArray(new Player[state.getPlayers().length()]);
+            // calculate the full time of the current played game
+            int fulltime = 0;
+            for (Player player : players) {
+                fulltime = fulltime + (int)(game.getClocks().get(player.getIndex()).getTime());
+            }
             for (Player player : players) {
                 gridy = 0;
                 Color color = player.getColors().getMeepleColor();
@@ -200,8 +205,13 @@ public class GameOverPanel extends JPanel {
                 seconds = seconds % 3600;
                 int minutes = seconds / 60;
                 seconds = seconds % 60;
-                add(new JLabel(String.format("%d:%02d:%02d", hours, minutes, seconds), SwingConstants.CENTER), getSpec(gridx, gridy++));
-
+                int fullseconds = fulltime / 1000;
+                int fullhours = fullseconds / 3600;
+                fullseconds = fullseconds % 3600;
+                int fullminutes = fullseconds / 60;
+                fullseconds = fullseconds % 60;
+                add(new JLabel(String.format("%d:%02d:%02d/%d:%02d:%02d", hours, minutes, seconds, fullhours, fullminutes, fullseconds), SwingConstants.CENTER), getSpec(gridx, gridy++));
+               
                 add(new JLabel("" +player.getPointsInCategory(state, PointCategory.ROAD), SwingConstants.CENTER), getSpec(gridx, gridy++));
                 add(new JLabel("" +player.getPointsInCategory(state, PointCategory.CITY), SwingConstants.CENTER), getSpec(gridx, gridy++));
                 add(new JLabel("" +player.getPointsInCategory(state, PointCategory.CLOISTER), SwingConstants.CENTER), getSpec(gridx, gridy++));


### PR DESCRIPTION
Hi, decided to add the consumed time of the game next to time consumed of each player in java class: "src/main/java/com/jcloisterzone/ui/panel/GameOverPanel.java". The differences from before and after are in the following images. Also updated the texts in the file "po" except for the "po/cs.po" because it has already had a translation and I did not know it. All the others did not have a translation.
![Time_Consumed_Before](https://user-images.githubusercontent.com/24796302/60761956-c2f85200-a05c-11e9-8737-1db87b9fa390.png)
![Time_Consumed_After](https://user-images.githubusercontent.com/24796302/60761957-c68bd900-a05c-11e9-8343-185434144d3f.png)

