### PR TITLE
add option 2 points for small cities

### DIFF
--- a/src/main/java/com/jcloisterzone/feature/City.java
+++ b/src/main/java/com/jcloisterzone/feature/City.java
@@ -8,6 +8,7 @@ import com.jcloisterzone.board.Position;
 import com.jcloisterzone.board.Rotation;
 import com.jcloisterzone.board.ShortEdge;
 import com.jcloisterzone.board.pointer.FeaturePointer;
+import com.jcloisterzone.game.Rule;
 import com.jcloisterzone.game.capability.TradeGoodsCapability.TradeGoods;
 import com.jcloisterzone.game.state.GameState;
 
@@ -189,7 +190,11 @@ public class City extends CompletableFeature<City> {
                 pointsPerUnit--;
             }
         }
-        return pointsPerUnit * (tileCount + pennants);
+        if (state.getBooleanValue(Rule.MINI_CITIES_ONLY_TWO_POINTS) && tileCount + pennants == 2) {
+            return 2;
+        } else {
+            return pointsPerUnit * (tileCount + pennants);
+        }
     }
 
     @Override

--- a/src/main/java/com/jcloisterzone/game/Rule.java
+++ b/src/main/java/com/jcloisterzone/game/Rule.java
@@ -16,6 +16,7 @@ public enum Rule {
     RANDOM_SEATING_ORDER(null, Boolean.class,  _tr("Randomize seating order")),
 
     USE_PIG_HERDS_INDEPENDENTLY(Expansion.BASIC, Boolean.class, _tr("Use pig herds independently (without T&B expansion)")),
+    MINI_CITIES_ONLY_TWO_POINTS(Expansion.BASIC, Boolean.class, _tr("Only 2 points for small cities of 2 tiles with no pennants.")),
 
     PRINCESS_MUST_REMOVE_KNIGHT(Expansion.PRINCESS_AND_DRAGON, Boolean.class, _tr("Princess MUST remove a knight from city.") + " (RGG, ZMG)"),
     DRAGON_MOVE_AFTER_SCORING(Expansion.PRINCESS_AND_DRAGON, Boolean.class, _tr("Dragon movement occurs after scoring.") + " (RGG)"),


### PR DESCRIPTION
Because we play it usually like that, I added a rule option for small cities to be counted as 2 points as in official rules before 2002 (see e.g. https://www.carc-forum.de/viewtopic.php?f=277&t=504 ).
![carc-1](https://user-images.githubusercontent.com/6549824/68200158-9aa74280-ffbf-11e9-9c95-01235cda491c.png)