### PR TITLE
Fixed time consumed (playtime + percentage)

### DIFF
--- a/src/main/java/com/jcloisterzone/PlayerClock.java
+++ b/src/main/java/com/jcloisterzone/PlayerClock.java
@@ -11,6 +11,9 @@ public class PlayerClock implements Serializable {
     private final boolean running;
     private final long runningSince;
 
+    /**
+     * @param time in ms
+     */
     public PlayerClock(long time) {
         this(time, false, 0);
     }
@@ -26,6 +29,9 @@ public class PlayerClock implements Serializable {
     }
 
 
+    /**
+     * @return playtime in milliseconds
+     */
     public long getTime() {
         if (running) {
             return time + System.currentTimeMillis() - runningSince;

--- a/src/main/java/com/jcloisterzone/PlayerClock.java
+++ b/src/main/java/com/jcloisterzone/PlayerClock.java
@@ -30,7 +30,7 @@ public class PlayerClock implements Serializable {
 
 
     /**
-     * @return playtime in milliseconds
+     * @return playtime in ms
      */
     public long getTime() {
         if (running) {

--- a/src/test/java/com/jcloisterzone/ui/panel/GameOverPanelTest.java
+++ b/src/test/java/com/jcloisterzone/ui/panel/GameOverPanelTest.java
@@ -1,0 +1,64 @@
+package com.jcloisterzone.ui.panel;
+
+import com.jcloisterzone.Player;
+import com.jcloisterzone.PlayerClock;
+import com.jcloisterzone.game.Game;
+import io.vavr.collection.Array;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.jcloisterzone.ui.panel.GameOverPanel.formatPercentageString;
+import static com.jcloisterzone.ui.panel.GameOverPanel.formatPlaytimeString;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GameOverPanelTest {
+
+    @Test
+    public void shouldCalculatePlaytimeCorrectly() {
+        Game game = mock(Game.class);
+        Player player = mock(Player.class);
+
+        Array<PlayerClock> playerClocks = Array.of(new PlayerClock(20_052_123));
+        when(game.getClocks()).thenReturn(playerClocks);
+        when(player.getIndex()).thenReturn(0);
+
+        Playtime playtime = new Playtime(game, player, 30_000);
+
+        assertEquals(5, playtime.getHours());
+        assertEquals(34, playtime.getMinutes());
+        assertEquals(12, playtime.getSeconds());
+        assertEquals(8, playtime.getTotalHours());
+        assertEquals(20, playtime.getTotalMinutes());
+        assertEquals(0, playtime.getTotalSeconds());
+        assertEquals(66.84f, playtime.getPercentage(), 1e-2);
+    }
+
+    @Test
+    public void shouldFormatPercentageStringCorrectly() {
+        Playtime playtimeMock = mock(Playtime.class);
+        when(playtimeMock.getPercentage()).thenReturn(66.84f);
+
+        String percentageString = formatPercentageString(playtimeMock);
+
+        assertEquals("67%", percentageString);
+    }
+
+    @Test
+    public void shouldFormatPlaytimeStringCorrectly() {
+        Playtime playtimeMock = mock(Playtime.class);
+        when(playtimeMock.getHours()).thenReturn(5);
+        when(playtimeMock.getMinutes()).thenReturn(34);
+        when(playtimeMock.getSeconds()).thenReturn(12);
+        when(playtimeMock.getTotalHours()).thenReturn(8);
+        when(playtimeMock.getTotalMinutes()).thenReturn(20);
+        when(playtimeMock.getTotalSeconds()).thenReturn(0);
+
+        String playtimeString = formatPlaytimeString(playtimeMock);
+
+        assertEquals("5:34:12/\n8:20:00", playtimeString);
+    }
+}


### PR DESCRIPTION
Hi!

I have implemented a fix for issue #319. As shown in the screenshot below, time consumed now works. Since the individual play times don't add up to the total play time, the percentages don't add up to 100%.

![jcloisterzonefixcropped](https://user-images.githubusercontent.com/44864267/81596761-e8fd2a00-93c4-11ea-8e72-50837dbe19cc.png)

Best regards
Chris