### PR TITLE
Fixed PlayerClock

### DIFF
--- a/src/main/java/com/jcloisterzone/PlayerClock.java
+++ b/src/main/java/com/jcloisterzone/PlayerClock.java
@@ -2,24 +2,23 @@ package com.jcloisterzone;
 
 import java.io.Serializable;
 
-@Immutable
 public class PlayerClock implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final long time;
-    private final boolean running;
-    private final long runningSince;
+    private long time;
+    private boolean running;
+    private long runningSince;
+
+    public PlayerClock() {
+        this(0);
+    }
 
     /**
      * @param time in ms
      */
-    public PlayerClock(long time) {
+    public PlayerClock(int time) {
         this(time, false, 0);
-    }
-
-    public PlayerClock(long time, boolean running) {
-        this(time, running, running ? System.currentTimeMillis() : 0);
     }
 
     public PlayerClock(long time, boolean running, long runningSince) {
@@ -40,28 +39,16 @@ public class PlayerClock implements Serializable {
         }
     }
 
-    /**
-     * Returns time ignoring runningSince (which is reset to now)
-     */
-    public PlayerClock resetRunning() {
-        return new PlayerClock(time, running, System.currentTimeMillis());
-    }
-
-    public PlayerClock setTime(long time) {
-        if (!running && this.time == time) {
-            return this;
+    public void setRunning(boolean setRunning) {
+        // start running
+        if (!this.running && setRunning) {
+            this.running = true;
+            this.runningSince = System.currentTimeMillis();
         }
-        return new PlayerClock(time, running, running ? System.currentTimeMillis() : 0);
-    }
-
-    public boolean isRunning() {
-        return running;
-    }
-
-    public PlayerClock setRunning(boolean running) {
-        if (this.running == running) {
-            return this;
+        // stop running
+        if (this.running && !setRunning){
+            this.running = false;
+            time += System.currentTimeMillis() - runningSince;
         }
-        return new PlayerClock(time, running, running ? System.currentTimeMillis() : 0);
     }
 }

--- a/src/main/java/com/jcloisterzone/PlayerClock.java
+++ b/src/main/java/com/jcloisterzone/PlayerClock.java
@@ -17,7 +17,7 @@ public class PlayerClock implements Serializable {
     /**
      * @param time in ms
      */
-    public PlayerClock(int time) {
+    public PlayerClock(long time) {
         this(time, false, 0);
     }
 

--- a/src/main/java/com/jcloisterzone/game/Game.java
+++ b/src/main/java/com/jcloisterzone/game/Game.java
@@ -295,10 +295,7 @@ public class Game implements EventProxy {
         for (int i = 0; i < clockValues.length; i++) {
             boolean running = msg.getRunning() != null && msg.getRunning() == i;
             PlayerClock clock = clocks.get(i);
-            PlayerClock newClock = clock.setRunning(running).setTime(clockValues[i]);
-            if (clock != newClock) {
-                clocks = clocks.update(i, newClock);
-            }
+            clock.setRunning(running);
         }
         post(new ClockUpdateEvent(clocks, msg.getRunning()));
     }
@@ -356,7 +353,7 @@ public class Game implements EventProxy {
         // 1. create state with basic config
         GameState state = builder.createInitialState();
         this.state = state; // set state to get proper state diff against empty state later (in replacedState)
-        clocks = state.getPlayers().getPlayers().map(p -> new PlayerClock(0));
+        clocks = state.getPlayers().getPlayers().map(p -> new PlayerClock());
 
         // 2. Register local AI players
         createAiPlayers(gc);

--- a/src/main/java/com/jcloisterzone/wsio/message/ClockMessage.java
+++ b/src/main/java/com/jcloisterzone/wsio/message/ClockMessage.java
@@ -10,9 +10,6 @@ public class ClockMessage extends AbstractWsMessage implements WsInGameMessage {
     private long[] clocks;
     private long currentTime;
 
-    public ClockMessage() {
-    }
-
     public ClockMessage(Integer running, long[] clocks, long currentTime) {
         this.running = running;
         this.clocks = clocks;
@@ -39,18 +36,6 @@ public class ClockMessage extends AbstractWsMessage implements WsInGameMessage {
 
     public long[] getClocks() {
         return clocks;
-    }
-
-    public void setClocks(long[] clocks) {
-        this.clocks = clocks;
-    }
-
-    public long getCurrentTime() {
-        return currentTime;
-    }
-
-    public void setCurrentTime(long currentTime) {
-        this.currentTime = currentTime;
     }
 
 }


### PR DESCRIPTION
Hey there!

After my previous PR #323 I've noticed that the time gets displayed properly, but not measured correctly. After a 20+ minute game the total time was apparently just 1:50 min.

I have refactored the PlayerClock and it now works perfectly - in local and remote play. The individual play times add up exactly to the total play time and the percentages add up to 100%. I have measured the play time and it's correct as well.

There is a lot of dead code now - for example ClockMessages (`ClockMessage.java`) are now only used to check if a clock should be running - the actual times are ignored. So everything is calculated locally. I'm not sure why the clock times have been transmitted previously, but it doesn't seem to be necessary.

![v3](https://user-images.githubusercontent.com/44864267/81612156-a9423c80-93dc-11ea-8131-25df12b35d74.PNG)

The names in the screenshot are missing, but that's because it was a local game and I hadn't entered any. As I said, remote play works as well.


Best regards
Chris