### PR TITLE
Fix scroll behaviour via keys and improve scroll speed

### DIFF
--- a/src/main/java/com/jcloisterzone/ui/MenuBar.java
+++ b/src/main/java/com/jcloisterzone/ui/MenuBar.java
@@ -34,8 +34,8 @@ public class MenuBar extends JMenuBar {
         QUIT(_tr("Quit"), KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())),
         //Game
         UNDO(_tr("Undo"), KeyStroke.getKeyStroke(KeyEvent.VK_Z, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())),
-        ZOOM_IN(_tr("Zoom In"), KeyStroke.getKeyStroke('+')),
-        ZOOM_OUT(_tr("Zoom Out"), KeyStroke.getKeyStroke('-')),
+        ZOOM_IN(_tr("Zoom In")),
+        ZOOM_OUT(_tr("Zoom Out")),
         ROTATE_BOARD(_tr("Rotate Board"), KeyStroke.getKeyStroke('/')),
         GAME_EVENTS(_tr("Show Game Events"), KeyStroke.getKeyStroke('e')),
         LAST_PLACEMENTS(_tr("Show Last Placements"), KeyStroke.getKeyStroke('x')),

--- a/src/main/java/com/jcloisterzone/ui/grid/GridPanel.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/GridPanel.java
@@ -272,7 +272,7 @@ public class GridPanel extends JPanel implements ForwardBackwardListener, UIEven
         addMouseWheelListener(new MouseWheelListener() {
             @Override
             public void mouseWheelMoved(MouseWheelEvent e) {
-                zoom(-e.getWheelRotation());
+                zoom(-e.getWheelRotation() * 0.5);
             }
         });
     }

--- a/src/main/java/com/jcloisterzone/ui/view/GameView.java
+++ b/src/main/java/com/jcloisterzone/ui/view/GameView.java
@@ -291,6 +291,14 @@ public class GameView extends AbstractUiView implements WindowStateListener, Gam
     }
 
     private boolean dispatchReptable(KeyEvent e, boolean pressed) {
+        if (e.getKeyChar() == '+') {
+            repeatZoomIn = pressed;
+            return true;
+        }
+        if (e.getKeyChar() == '-') {
+            repeatZoomOut = pressed;
+            return true;
+        }
         if (e.getModifiers() != 0) return false;
         switch (e.getKeyCode()) {
         case KeyEvent.VK_LEFT:
@@ -308,14 +316,6 @@ public class GameView extends AbstractUiView implements WindowStateListener, Gam
         case KeyEvent.VK_UP:
         case KeyEvent.VK_W:
             repeatUp = pressed;
-            return true;
-        }
-        if (e.getKeyChar() == '+') {
-            repeatZoomIn = pressed;
-            return true;
-        }
-        if (e.getKeyChar() == '-') {
-            repeatZoomOut = pressed;
             return true;
         }
         return false;
@@ -449,10 +449,10 @@ public class GameView extends AbstractUiView implements WindowStateListener, Gam
                 gridPanel.moveCenter(0, 1);
             }
             if (repeatZoomIn) {
-                gridPanel.zoom(0.8);
+                gridPanel.zoom(0.3);
             }
             if (repeatZoomOut) {
-                gridPanel.zoom(-0.8);
+                gridPanel.zoom(-0.3);
             }
         }
     }


### PR DESCRIPTION
* Fixes key-repeat behaviour on keyboards where `+` requires a shift key
* Removes additional zoom triggered via menu hotkey
* Tweaks scroll speed to be slightly slower to allow better control, both via keyboard and via mouse

I could separate these into fix and tweak, let me know if you want me to split these into two commits/PRs. 