### PR TITLE
Add new way to place tiles

### DIFF
--- a/src/main/java/com/jcloisterzone/config/Config.java
+++ b/src/main/java/com/jcloisterzone/config/Config.java
@@ -47,6 +47,12 @@ public class Config {
     private String secret;
     private String play_online_host;
 
+    public enum MousePlacement {
+        PLACE,
+        PLACE_AND_ROTATE
+    }
+    private MousePlacement mouse_placement;
+
     private ConfirmConfig confirm;
     private AiConfig ai;
     private PlayersConfig players;
@@ -436,6 +442,13 @@ public class Config {
         this.beep_alert = beep_alert;
     }
 
+    public MousePlacement getMouse_placement() {
+        return mouse_placement;
+    }
+
+    public void setMouse_placement(MousePlacement mouse_placement) {
+        this.mouse_placement = mouse_placement;
+    }
 
     public PluginsConfig getPlugins() {
         if (plugins == null) {

--- a/src/main/java/com/jcloisterzone/config/ConfigLoader.java
+++ b/src/main/java/com/jcloisterzone/config/ConfigLoader.java
@@ -146,6 +146,7 @@ public class ConfigLoader {
         config.getAi().setClass_name(DEFAULT_AI_CLASS_NAME);
         config.setTheme(DEFAULT_THEME);
         config.setClient_name("");
+        config.setMouse_placement(Config.MousePlacement.PLACE);
         config.setPlay_online_host(DEFAULT_PLAY_ONLINE_HOST);
         config.setClient_id(KeyUtils.createRandomId());
         config.setSecret(KeyUtils.createRandomId());
@@ -185,6 +186,7 @@ public class ConfigLoader {
         model.put("score_display_duration", config.getScore_display_duration());
         model.put("theme", config.getTheme());
         model.put("beep_alert", config.getBeep_alert());
+        model.put("mouse_placement", config.getMouse_placement());
         model.put("client_name", config.getClient_name());
         model.put("play_online_host", config.getPlay_online_host());
         model.put("client_id", config.getClient_id());

--- a/src/main/java/com/jcloisterzone/ui/dialog/PreferencesDialog.java
+++ b/src/main/java/com/jcloisterzone/ui/dialog/PreferencesDialog.java
@@ -65,6 +65,7 @@ public class PreferencesDialog extends JDialog {
 
     private JComboBox<StringOption> langComboBox;
     private JComboBox<StringOption> themeComboBox;
+    private JComboBox<EnumOption<Config.MousePlacement>> mousePlacementComboBox;
     private JTextField aiPlaceTileDelay;
     private JTextField scoreDisplayDuration;
     private List<PluginModel> pluginRows = new ArrayList<>();
@@ -78,6 +79,25 @@ public class PreferencesDialog extends JDialog {
         }
 
         public String getKey() {
+            return key;
+        }
+
+        @Override
+        public String toString() {
+            return title;
+        }
+    }
+
+    private static class EnumOption<T extends Enum> {
+        private final String title;
+        private final T key;
+
+        public EnumOption(T key, String title) {
+            this.key = key;
+            this.title = title;
+        }
+
+        public T getKey() {
             return key;
         }
 
@@ -142,6 +162,19 @@ public class PreferencesDialog extends JDialog {
         initialTheme = config.getTheme();
     }
 
+    private void initRotateBasedOnMousePositionOptions(JComboBox<EnumOption<Config.MousePlacement>> comboBox) {
+        List<EnumOption> result = new ArrayList<>();
+        result.add(new EnumOption(Config.MousePlacement.PLACE, _tr("Place tile")));
+        result.add(new EnumOption(Config.MousePlacement.PLACE_AND_ROTATE, _tr("Place and rotate tile")));
+
+        for (EnumOption<Config.MousePlacement> opt : result) {
+            comboBox.addItem(opt);
+            if (opt.getKey() == config.getMouse_placement()) {
+                comboBox.setSelectedItem(opt);
+            }
+        }
+    }
+
     private String valueOf(Object obj) {
         if (obj == null) return "";
         return obj.toString();
@@ -158,6 +191,8 @@ public class PreferencesDialog extends JDialog {
         config.setLocale(opt.getKey());
         opt = (StringOption) themeComboBox.getSelectedItem();
         config.setTheme(opt.getKey());
+        EnumOption<Config.MousePlacement> mousePlacementOption = (EnumOption<Config.MousePlacement>) mousePlacementComboBox.getSelectedItem();
+        config.setMouse_placement(mousePlacementOption.key);
         //TODO error handling
         config.getAi().setPlace_tile_delay(intValue(aiPlaceTileDelay.getText()));
         config.setScore_display_duration(intValue(scoreDisplayDuration.getText()));
@@ -229,6 +264,12 @@ public class PreferencesDialog extends JDialog {
         themeHint.setFont(HINT_FONT);
         themeHint.setForeground(client.getTheme().getHintColor());
         panel.add(themeHint, "sx 2, wrap");
+
+        panel.add(new ThemedJLabel(_tr("Tile placement via mouse")), "alignx trailing");
+
+        mousePlacementComboBox = new JComboBox();
+        initRotateBasedOnMousePositionOptions(mousePlacementComboBox);
+        panel.add(mousePlacementComboBox, "wrap, growx");
 
         panel.add(new ThemedJLabel(_tr("AI placement delay (ms)")), "gaptop 10, alignx trailing");
 

--- a/src/main/java/com/jcloisterzone/ui/grid/GridMouseAdapter.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/GridMouseAdapter.java
@@ -46,6 +46,7 @@ public class GridMouseAdapter extends MouseAdapter implements MouseInputListener
             currentPosition = p;
             listener.tileEntered(e, currentPosition);
         }
+        listener.mouseMoved(e, p);
     }
 
     @Override

--- a/src/main/java/com/jcloisterzone/ui/grid/GridMouseListener.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/GridMouseListener.java
@@ -10,4 +10,5 @@ public interface GridMouseListener {
     void tileExited(MouseEvent e, Position p);
 
     void mouseClicked(MouseEvent e, Position p);
+    default void mouseMoved(MouseEvent e, Position p) {}
 }

--- a/src/main/java/com/jcloisterzone/ui/grid/layer/AbstractGridLayer.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/layer/AbstractGridLayer.java
@@ -22,6 +22,7 @@ import com.jcloisterzone.board.Location;
 import com.jcloisterzone.board.Position;
 import com.jcloisterzone.board.Rotation;
 import com.jcloisterzone.board.pointer.FeaturePointer;
+import com.jcloisterzone.config.Config;
 import com.jcloisterzone.feature.Feature;
 import com.jcloisterzone.game.Game;
 import com.jcloisterzone.game.state.GameState;
@@ -215,6 +216,10 @@ public abstract class AbstractGridLayer implements GridLayer, UIEventListener {
 
     protected Game getGame() {
         return gc.getGame();
+    }
+
+    protected Config getConfig() {
+        return gc.getConfig();
     }
 
     @Deprecated //TODO use absolute coordinates instead

--- a/src/main/java/com/jcloisterzone/ui/grid/layer/LittleBuildingActionLayer.java
+++ b/src/main/java/com/jcloisterzone/ui/grid/layer/LittleBuildingActionLayer.java
@@ -146,38 +146,28 @@ public class LittleBuildingActionLayer extends AbstractGridLayer implements Acti
 
     }
 
-    private class MoveTrackingGridMouseAdapter extends GridMouseAdapter {
-
-        public MoveTrackingGridMouseAdapter(GridPanel gridPanel, GridMouseListener listener) {
-            super(gridPanel, listener);
-        }
-
-        @Override
-        public void mouseMoved(MouseEvent e) {
-            super.mouseMoved(e);
-            Point2D point = gridPanel.getRelativePoint(e.getPoint());
-            int x = (int) point.getX();
-            int y = (int) point.getY();
-            LittleBuilding newValue = null;
-            for (Entry<LittleBuilding, Rectangle> entry : areas.entrySet()) {
-                if (entry.getValue().contains(x, y)) {
-                    newValue = entry.getKey();
-                    break;
-                }
-            }
-            if (newValue != selected) {
-                selected = newValue;
-                gridPanel.repaint();
+    @Override
+    public void mouseMoved(MouseEvent e, Position p) {
+        Point2D point = gridPanel.getRelativePoint(e.getPoint());
+        int x = (int) point.getX();
+        int y = (int) point.getY();
+        LittleBuilding newValue = null;
+        for (Entry<LittleBuilding, Rectangle> entry : areas.entrySet()) {
+            if (entry.getValue().contains(x, y)) {
+                newValue = entry.getKey();
+                break;
             }
         }
-
+        if (newValue != selected) {
+            selected = newValue;
+            gridPanel.repaint();
+        }
     }
 
     @Override
     public void onShow() {
         super.onShow();
-        //TODO extract listener from this
-        attachMouseInputListener(new MoveTrackingGridMouseAdapter(gridPanel, this));
+        attachMouseInputListener(new GridMouseAdapter(gridPanel, this));
     }
 
     @Override


### PR DESCRIPTION
This commit adds a new way to place and rotate tiles
at the same time. It also shows which rotations are possible.

Since people are probably used to the current placement
option I've added this one as a setting and used the 'old' one
as a default.

![image](https://user-images.githubusercontent.com/158185/82825798-ca5a6100-9ea3-11ea-8c11-d8da8076ecd9.png)


----

small note: While I believe that other players might prefer this mode for normal playing, the primary reason for this PR is that we have started playing JCloisterZone via Zoom. One player starts the game and the other watch and tell them where to place tiles when it's their turn. 

Having a way to do all interaction by simple mouse movements makes it easier when one of the "observers" wants to take over (zoom allows the mouse to be taken over) and the rotation handles make it easier to describe which way around a tile should go.