### PR TITLE
Add scoring other closed farms to scoreFlock.

### DIFF
--- a/src/main/java/com/jcloisterzone/game/phase/ShepherdPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/ShepherdPhase.java
@@ -106,6 +106,10 @@ public class ShepherdPhase extends Phase {
 	private StepResult scoreFlock(GameState state, FeaturePointer shepherdFp) {
 		Farm farm = (Farm) state.getFeature(shepherdFp);
 		state = scoreFlock(state, farm);
+                Seq<Farm> closedFarmsWithShepherd = getClosedFarmsWithShepherd(state);
+                for (Farm closedFarm : closedFarmsWithShepherd) {
+				state = scoreFlock(state, closedFarm);
+		}
 		state = clearActions(state);
 		return next(state);
 	}


### PR DESCRIPTION
This fixes a potential case where someone's shepherd that was closed could be left behind in their field if their opponent scored the opponent shepherd.