### PR TITLE
Fix "key" to key for predefined members

### DIFF
--- a/src/main/java/com/jcloisterzone/feature/ModifiedFeature.java
+++ b/src/main/java/com/jcloisterzone/feature/ModifiedFeature.java
@@ -73,7 +73,7 @@ public interface ModifiedFeature<C extends ModifiedFeature> extends Feature {
             try (Context context = Context.create("js")) {
                 Value bindings = context.getBindings("js");
                 members.forEach((key, value) -> {
-                    bindings.putMember("key", value);
+                    bindings.putMember(key, value);
                 });
 
                 getModifiers().forEach((mod, value) -> {


### PR DESCRIPTION
For example Cities send "tileCount" and "completed" but it is not processed in scoreScriptedModifiers method.