### PR TITLE
Fix Scoring Acrobats

### DIFF
--- a/src/main/java/com/jcloisterzone/game/capability/AcrobatsCapability.java
+++ b/src/main/java/com/jcloisterzone/game/capability/AcrobatsCapability.java
@@ -49,9 +49,9 @@ public class AcrobatsCapability extends Capability<Void> {
             FeaturePointer fp = feature.getPlace();
             if (placedBridges.contains(fp.getPosition())) continue;
 
-            if (meeplesCount == FULL_ACROBATS) {
+            if (meeplesCount >= FULL_ACROBATS) {
                 acrobatsToScore = acrobatsToScore.add(fp);
-            } else {
+            } else if (meeple != null) {
                 Position pos = fp.getPosition();
                 boolean canPlace = hasMagicPortal || Math.abs(currentTilePos.x - pos.x) <= 1 && Math.abs(currentTilePos.y - pos.y) <= 1;
                 if (canPlace) {

--- a/src/main/java/com/jcloisterzone/game/capability/BigTopCapability.java
+++ b/src/main/java/com/jcloisterzone/game/capability/BigTopCapability.java
@@ -9,6 +9,7 @@ import com.jcloisterzone.figure.Follower;
 import com.jcloisterzone.figure.Meeple;
 import com.jcloisterzone.figure.neutral.BigTop;
 import com.jcloisterzone.game.Capability;
+import com.jcloisterzone.game.capability.LittleBuildingsCapability.LittleBuilding;
 import com.jcloisterzone.game.state.GameState;
 import com.jcloisterzone.reducers.AddPoints;
 import io.vavr.collection.*;
@@ -59,7 +60,7 @@ public class BigTopCapability extends Capability<Integer> {
 
         for (var t : adjacentMeepleCount) {
             int followers = t._2.size();
-            ExprItem expr = new ExprItem(followers, "meeples", token.points * followers);
+            ExprItem expr = new ExprItem(followers, "bigtop." + token.name(), token.points * followers);
             points = points.append(new ScoreEvent.ReceivedPoints(new PointsExpression("bigtop", expr), t._1, pos));
         }
 

--- a/src/main/java/com/jcloisterzone/game/capability/TowerCapability.java
+++ b/src/main/java/com/jcloisterzone/game/capability/TowerCapability.java
@@ -75,7 +75,7 @@ public final class TowerCapability extends Capability<Array<List<Follower>>> {
         if (!openTowersForFollower.isEmpty()) {
             Vector<Meeple> availMeeples = player.getMeeplesFromSupply(
                 state,
-                Vector.of(SmallFollower.class, BigFollower.class, Phantom.class)
+                Vector.of(SmallFollower.class, BigFollower.class, Phantom.class, Ringmaster.class)
             );
             Vector<PlayerAction<?>> actions = availMeeples.map(meeple ->
                 new MeepleAction(meeple, openTowersForFollower)

--- a/src/main/java/com/jcloisterzone/game/phase/CocFollowerPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/CocFollowerPhase.java
@@ -64,7 +64,7 @@ public class CocFollowerPhase extends Phase {
 
         Vector<Class<? extends Meeple>> meepleTypes = Vector.of(
             SmallFollower.class, BigFollower.class, Phantom.class,
-            Wagon.class, Mayor.class
+            Wagon.class, Mayor.class, Ringmaster.class
         );
         Vector<Meeple> availMeeples = player.getMeeplesFromSupply(state, meepleTypes);
         boolean marketAllowed = state.getBooleanRule(Rule.FARMERS);

--- a/src/main/java/com/jcloisterzone/game/phase/CornCirclePhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/CornCirclePhase.java
@@ -96,7 +96,7 @@ public class CornCirclePhase extends Phase {
 
         switch (option) {
         case DEPLOY:
-            Vector<Class<? extends Meeple>> meepleTypes = Vector.of(SmallFollower.class, BigFollower.class, Phantom.class);
+            Vector<Class<? extends Meeple>> meepleTypes = Vector.of(SmallFollower.class, BigFollower.class, Phantom.class, Ringmaster.class);
             if (!cornType.equals(Field.class)) {
                 meepleTypes = meepleTypes.append(Wagon.class);
             }


### PR DESCRIPTION
Fix issue, when Small Follower was not available, then Acrobats was not able to score event they were possible.
Also solving possible issue for future 20 Anniversary Expansion which allows to player add meeple next to any his meeple on board. Which means, possibly it can be more than 3 meeples in Pyramid.