### PR TITLE
Fairy bonus for all current player meeples on Acrobats

### DIFF
--- a/src/main/java/com/jcloisterzone/game/phase/FairyPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/FairyPhase.java
@@ -7,6 +7,7 @@ import com.jcloisterzone.board.pointer.MeeplePointer;
 import com.jcloisterzone.event.ExprItem;
 import com.jcloisterzone.event.PointsExpression;
 import com.jcloisterzone.event.ScoreEvent.ReceivedPoints;
+import com.jcloisterzone.feature.Acrobats;
 import com.jcloisterzone.figure.Meeple;
 import com.jcloisterzone.game.capability.FairyCapability;
 import com.jcloisterzone.game.state.GameState;
@@ -36,14 +37,16 @@ public class FairyPhase extends Phase {
             if (!m.getPlayer().equals(state.getTurnPlayer())) continue;
             if (onTileRule) {
                 if (!t._2.getPosition().equals(fairyFp.getPosition())) continue;
-            } else {
+            } else if (!(m.getFeature(state) instanceof Acrobats)) {
                 if (!t._2.equals(fairyFp)) continue;
-                if (!((MeeplePointer) ptr).match(m)) continue;
+               	if (!((MeeplePointer) ptr).match(m)) continue;
             }
 
             PointsExpression expr = new PointsExpression("fairy.turn", new ExprItem("fairy", FairyCapability.FAIRY_POINTS_BEGINNING_OF_TURN));
             state = (new AddPoints(new ReceivedPoints(expr, m.getPlayer(), fairyFp), false)).apply(state);
-            break;
+            if (!(m.getFeature(state) instanceof Acrobats)) {
+                break;
+            }
         }
 
         return next(state);

--- a/src/main/java/com/jcloisterzone/game/phase/FairyPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/FairyPhase.java
@@ -31,15 +31,28 @@ public class FairyPhase extends Phase {
 
         boolean onTileRule = ptr instanceof Position;
         FeaturePointer fairyFp = ptr.asFeaturePointer();
-
-        for (Tuple2<Meeple, FeaturePointer> t : state.getDeployedMeeples()) {
+        GameState _state = state;
+        
+        Set<Tuple2<Meeple, FeaturePointer>> playerMeeplesOnTileWithFairy = state.getDeployedMeeples()
+        		.filter(t -> t._1.getPlayer().equals(_state.getTurnPlayer()))
+        		.filter(t -> t._2.getPosition().equals(fairyFp.getPosition()))
+        		.toSet();
+        
+        boolean isAcrobats = !playerMeeplesOnTileWithFairy
+        		.filter(t -> t._1.getFeature(_state) instanceof Acrobats)
+        		.isEmpty();
+        
+        for (Tuple2<Meeple, FeaturePointer> t : playerMeeplesOnTileWithFairy) {
             Meeple m = t._1;
-            if (!m.getPlayer().equals(state.getTurnPlayer())) continue;
             if (onTileRule) {
-                if (!t._2.getPosition().equals(fairyFp.getPosition())) continue;
-            } else if (!(m.getFeature(state) instanceof Acrobats)) {
-                if (!t._2.equals(fairyFp)) continue;
-               	if (!((MeeplePointer) ptr).match(m)) continue;
+            	if (isAcrobats && !(m.getFeature(state) instanceof Acrobats)) {
+            		continue;
+            	}
+            } else {
+        		if (!t._2.equals(fairyFp)) continue;
+            	if (!(m.getFeature(state) instanceof Acrobats)) {
+            		if (!((MeeplePointer) ptr).match(m)) continue;
+            	}
             }
 
             PointsExpression expr = new PointsExpression("fairy.turn", new ExprItem("fairy", FairyCapability.FAIRY_POINTS_BEGINNING_OF_TURN));
@@ -51,4 +64,4 @@ public class FairyPhase extends Phase {
 
         return next(state);
     }
-}
+ }


### PR DESCRIPTION
By Rules of Expansion 10 in Interactions with Fairy:
```
You may assign the fairy to an acrobat, in which case it counts for all acrobats
in the pyramid (regardless of color). If the fairy is still there at the beginning
of your turn, you score 1 point for each of your meeples in the pyramid.
```