### PR TITLE
Wagon can never move to Castle, because Castle without meeple is considered as complete

### DIFF
--- a/src/main/java/com/jcloisterzone/game/phase/WagonPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/WagonPhase.java
@@ -53,8 +53,7 @@ public class WagonPhase extends Phase {
                         .filter(t -> {
                             Structure f = t._2;
                             if (f instanceof Castle) {
-                                Castle castle = (Castle) f;
-                                return !castle.isOccupied(_state);
+                            	return false;
                             }
                             if (f instanceof Completable) {
                                 Completable nei = (Completable) f;


### PR DESCRIPTION
Please use fix for The Wagon Move bug.
A Wagon can never mov to a Castle which is not occupied, because Castle without meeple is considered as completed. Thus wagon can not be placed there.