### PR TITLE
Reorder actions to move Phantom action at end of PlayerActions

### DIFF
--- a/src/main/java/com/jcloisterzone/game/phase/ActionPhase.java
+++ b/src/main/java/com/jcloisterzone/game/phase/ActionPhase.java
@@ -79,6 +79,8 @@ public class ActionPhase extends AbstractActionPhase {
                 state = state.setPlayerActions(new ActionsState(player, actions, false));
             }
         }
+        
+        state = state.setPlayerActions(state.getPlayerActions().reorderActions());
 
         if (state.getPlayerActions().getActions().isEmpty()) {
             state = clearActions(state);

--- a/src/main/java/com/jcloisterzone/game/state/ActionsState.java
+++ b/src/main/java/com/jcloisterzone/game/state/ActionsState.java
@@ -4,6 +4,7 @@ import com.jcloisterzone.Immutable;
 import com.jcloisterzone.Player;
 import com.jcloisterzone.action.MeepleAction;
 import com.jcloisterzone.action.PlayerAction;
+import com.jcloisterzone.figure.Phantom;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
 
@@ -100,6 +101,21 @@ public class ActionsState implements Serializable {
         actions = actions.appendAll(
             this.actions.filter(a -> !(a instanceof MeepleAction))
         ); // merge back all other non-MeepleActions
+        return setActions(actions);
+    }
+
+    /**
+     * Reorder actions to logical order, like Phantom at end of actions
+     *
+     * @return new instance with the logical order of Actions
+     */
+    public ActionsState reorderActions() {
+    	Vector<PlayerAction<?>> actions = this.actions.partition(
+    			a -> !(a instanceof MeepleAction)
+    			||
+    			!((MeepleAction) a).getMeepleType().equals(Phantom.class)
+    			).apply((nonPhantom, phantom) -> nonPhantom.appendAll(phantom));
+    
         return setActions(actions);
     }
 


### PR DESCRIPTION
In current version, when you have for example Phantom, Ringmaster and Abbot in your supply in Action phase (2. Placing a meeple) order of figures is:
1. Phantom
2. Abbot
3. Ringmaster

When you click to Phantom as first available option, Placing a meeple ends without possibility to place Abbot or Ringmaster, because Phantom placement is action after Abbot/Ringmaster is placed (or none is placed).

But when order is with this change:
1. Abbot
2. Ringmaster
3. Phantom

Then after placement of Abbot or Ringmaster will be possible to place Phantom as 2B-2 phase according to rules of The Phantom.